### PR TITLE
fix(storybook): restore wide peer dep ranges + add changesets for release

### DIFF
--- a/.changeset/deps-and-ts6.md
+++ b/.changeset/deps-and-ts6.md
@@ -1,0 +1,30 @@
+---
+'@vitus-labs/tools-typescript': major
+'@vitus-labs/tools-mcp': minor
+'@vitus-labs/tools-storybook': patch
+'@vitus-labs/tools-rolldown': patch
+'@vitus-labs/tools-rollup': patch
+'@vitus-labs/tools-nextjs': patch
+'@vitus-labs/tools-nextjs-images': patch
+'@vitus-labs/tools-vitest': patch
+'@vitus-labs/tools-core': patch
+'@vitus-labs/tools-atlas': patch
+'@vitus-labs/tools-favicon': patch
+'@vitus-labs/tools-lint': patch
+---
+
+Bulk dependency updates and TypeScript 6 migration.
+
+**Breaking (typescript)**: TypeScript peer dep bumped from `^5.9.3` to `^6.0.3`. Consumers must upgrade to TypeScript 6.
+
+**Notable internal updates**:
+- `@modelcontextprotocol/sdk` 1.27 → 1.29, `zod` 3 → 4 (mcp)
+- `vite` 7 → 8, `storybook` 10.2 → 10.3 (storybook)
+- `rolldown` rc.9 → rc.17, `rolldown-plugin-dts` 0.22 → 0.23 (rolldown)
+- `rollup` 4.59 → 4.60 (rollup)
+- `next` 16.1 → 16.2 (nextjs, nextjs-images)
+- `vitest` 4.1.0 → 4.1.5 (vitest)
+
+**Storybook peer deps restored**: Earlier auto-update inadvertently narrowed `react`, `react-dom`, `react-native`, and `react-native-web` peer ranges. Restored to original wide ranges.
+
+Other packages received patch-level dev dep bumps and a TypeScript 6 baseUrl cleanup in tsconfigs (no consumer-facing change).

--- a/bun.lock
+++ b/bun.lock
@@ -216,10 +216,10 @@
         "typescript": "^6.0.3",
       },
       "peerDependencies": {
-        "react": "^19.2.5",
-        "react-dom": "^19.2.5",
-        "react-native": "^0.84.1",
-        "react-native-web": "latest",
+        "react": ">=19",
+        "react-dom": ">=19",
+        "react-native": ">=0.74",
+        "react-native-web": ">=0.19",
       },
       "optionalPeers": [
         "react-native",

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -42,10 +42,10 @@
     "lint": "biome check src/"
   },
   "peerDependencies": {
-    "react": "^19.2.5",
-    "react-dom": "^19.2.5",
-    "react-native": "^0.84.1",
-    "react-native-web": "latest"
+    "react": ">=19",
+    "react-dom": ">=19",
+    "react-native": ">=0.74",
+    "react-native-web": ">=0.19"
   },
   "peerDependenciesMeta": {
     "react-native": {


### PR DESCRIPTION
## Summary

Two things bundled because they need to ship together:

### 1. Storybook peer dep restoration

PR #108's bulk dep update inadvertently narrowed `@vitus-labs/tools-storybook` peer dep ranges via \`bun update --latest\`, which would break consumers on older minor versions:

| dep | before #108 | after #108 (broken) | restored |
|---|---|---|---|
| react | \`>=19\` | \`^19.2.5\` | \`>=19\` |
| react-dom | \`>=19\` | \`^19.2.5\` | \`>=19\` |
| react-native | \`>=0.74\` | \`^0.84.1\` | \`>=0.74\` |
| react-native-web | \`>=0.19\` | \`latest\` | \`>=0.19\` |

(\`latest\` as a peer range is anti-pattern — unpredictable for consumers.)

### 2. Changesets for everything pending

PR #108 + #109 merged without changesets. Adding one changeset covering all pending package changes:

- **typescript**: major (peer dep TS 5 → 6 — breaking for consumers)
- **mcp**: minor (zod 3 → 4, MCP SDK 1.27 → 1.29)
- **storybook, rolldown, rollup, nextjs, nextjs-images, vitest, core, atlas, favicon, lint**: patch

## Test plan

- [x] All 542 tests pass
- [x] Lint and typecheck clean
- [x] All 10 packages build
- [x] After merge: changesets bot will open Version Packages PR → merge to publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)