### PR TITLE
feat(rolldown): expand external package names to match deep imports

### DIFF
--- a/.changeset/external-deep-imports.md
+++ b/.changeset/external-deep-imports.md
@@ -1,0 +1,9 @@
+---
+'@vitus-labs/tools-rolldown': minor
+---
+
+External package names now also match deep imports. Listing `echarts` as an external automatically externalizes `echarts/core`, `echarts/charts/BarChart`, etc. — no need to enumerate every subpath.
+
+This applies to both `package.json` dependencies/peerDependencies (auto-externalized) and entries in `CONFIG.external`. Users who need granular control can still pass a `RegExp` directly in `CONFIG.external` — it will be used as-is.
+
+**Behavior change**: previously, only exact-match strings were externalized. If you relied on a package's deep imports being bundled while the bare import was external, you'll need to handle that explicitly now.

--- a/packages/rolldown/src/rolldown/config.test.ts
+++ b/packages/rolldown/src/rolldown/config.test.ts
@@ -42,10 +42,16 @@ vi.mock('../config/index.js', () => ({
   PLATFORMS: ['browser', 'node', 'web', 'native'],
 }))
 
-import rolldownConfig, { buildDts } from './config.js'
+import rolldownConfig, { buildDts, expandExternal } from './config.js'
 
 const defaultConfig = { ...mockConfig }
 const defaultPKG = { ...mockPKG }
+
+const matchesExternal = (
+  externals: (string | RegExp)[] | undefined,
+  id: string,
+): boolean =>
+  (externals ?? []).some((e) => (typeof e === 'string' ? e === id : e.test(id)))
 
 describe('rolldownConfig', () => {
   beforeEach(() => {
@@ -65,8 +71,8 @@ describe('rolldownConfig', () => {
     expect(config.output.format).toBe('es')
     expect(config.output.sourcemap).toBe(true)
     expect(config.output.esModule).toBe(true)
-    expect(config.external).toContain('react')
-    expect(config.external).toContain('react/jsx-runtime')
+    expect(matchesExternal(config.external, 'react')).toBe(true)
+    expect(matchesExternal(config.external, 'react/jsx-runtime')).toBe(true)
   })
 
   it('should set platform to node for node builds', () => {
@@ -333,8 +339,8 @@ describe('buildDts', () => {
   it('should include external dependencies', () => {
     const result = buildDts()
 
-    expect(result?.external).toContain('react')
-    expect(result?.external).toContain('react/jsx-runtime')
+    expect(matchesExternal(result?.external, 'react')).toBe(true)
+    expect(matchesExternal(result?.external, 'react/jsx-runtime')).toBe(true)
   })
 
   it('should handle types path without slash', () => {
@@ -344,5 +350,77 @@ describe('buildDts', () => {
 
     expect(result?.output.dir).toBe('.')
     expect(result?.output.entryFileNames).toBe('index.d.ts')
+  })
+})
+
+describe('expandExternal', () => {
+  it('expands a bare package name to match deep imports', () => {
+    const re = expandExternal('echarts') as RegExp
+    expect(re.test('echarts')).toBe(true)
+    expect(re.test('echarts/core')).toBe(true)
+    expect(re.test('echarts/charts/BarChart')).toBe(true)
+  })
+
+  it('does not match unrelated packages with the same prefix', () => {
+    const re = expandExternal('echarts') as RegExp
+    expect(re.test('echartsjs')).toBe(false)
+    expect(re.test('echarts-extension')).toBe(false)
+  })
+
+  it('handles scoped packages', () => {
+    const re = expandExternal('@scope/pkg') as RegExp
+    expect(re.test('@scope/pkg')).toBe(true)
+    expect(re.test('@scope/pkg/sub')).toBe(true)
+    expect(re.test('@scope/other')).toBe(false)
+  })
+
+  it('passes RegExp inputs through unchanged', () => {
+    const original = /^foo$/
+    expect(expandExternal(original)).toBe(original)
+  })
+
+  it('escapes regex metacharacters in package names', () => {
+    const re = expandExternal('foo.bar') as RegExp
+    expect(re.test('foo.bar')).toBe(true)
+    expect(re.test('fooXbar')).toBe(false)
+  })
+})
+
+describe('rolldownConfig external deep imports', () => {
+  beforeEach(() => {
+    Object.assign(mockConfig, defaultConfig)
+    Object.assign(mockPKG, defaultPKG)
+  })
+
+  it('matches deep imports of dependencies', () => {
+    mockPKG.externalDependencies = ['echarts', 'react']
+    mockConfig.external = []
+
+    const config = rolldownConfig({
+      file: 'lib/index.js',
+      format: 'es',
+      env: 'development',
+      platform: 'universal',
+    })
+
+    expect(matchesExternal(config.external, 'echarts')).toBe(true)
+    expect(matchesExternal(config.external, 'echarts/core')).toBe(true)
+    expect(matchesExternal(config.external, 'echarts/charts/BarChart')).toBe(
+      true,
+    )
+    expect(matchesExternal(config.external, 'react/jsx-runtime')).toBe(true)
+  })
+
+  it('returns empty externals when bundleAll is enabled', () => {
+    mockConfig.bundleAll = true
+
+    const config = rolldownConfig({
+      file: 'lib/index.js',
+      format: 'es',
+      env: 'development',
+      platform: 'universal',
+    })
+
+    expect(config.external).toEqual([])
   })
 })

--- a/packages/rolldown/src/rolldown/config.ts
+++ b/packages/rolldown/src/rolldown/config.ts
@@ -6,6 +6,22 @@ import filesize from 'rollup-plugin-filesize'
 import { visualizer } from 'rollup-plugin-visualizer'
 import { CONFIG, PKG, PLATFORMS } from '../config/index.js'
 
+/**
+ * Convert a bare package name into a regex that matches the package itself
+ * AND any of its deep imports (e.g. `echarts` also matches `echarts/core`).
+ * Pass-through for RegExp inputs.
+ */
+const expandExternal = (id: string | RegExp): string | RegExp => {
+  if (id instanceof RegExp) return id
+  const escaped = id.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  return new RegExp(`^${escaped}(\\/.*)?$`)
+}
+
+const resolveExternals = (): (string | RegExp)[] =>
+  CONFIG.bundleAll
+    ? []
+    : [...PKG.externalDependencies, ...CONFIG.external].map(expandExternal)
+
 const defineExtensions = (platform: string) => {
   const platformExtensions: string[] = []
 
@@ -90,9 +106,7 @@ const rolldownConfig = ({
   const dir = lastSlash >= 0 ? file.substring(0, lastSlash) : '.'
   const entryFileName = lastSlash >= 0 ? file.substring(lastSlash + 1) : file
 
-  const external = CONFIG.bundleAll
-    ? []
-    : [...PKG.externalDependencies, ...CONFIG.external]
+  const external = resolveExternals()
 
   const buildOutput = {
     input: entryInput || CONFIG.sourceDir,
@@ -143,9 +157,7 @@ const createDtsConfig = (typesFilePath: string, inputFile: string) => {
     resolve: {
       extensions: CONFIG.extensions,
     },
-    external: CONFIG.bundleAll
-      ? []
-      : [...PKG.externalDependencies, ...CONFIG.external],
+    external: resolveExternals(),
     plugins: [
       ...(dts({
         tsconfig: 'tsconfig.json',
@@ -225,4 +237,4 @@ const buildAllDts = (): ReturnType<typeof createDtsConfig>[] => {
 }
 
 export default rolldownConfig
-export { buildAllDts, buildDts }
+export { buildAllDts, buildDts, expandExternal }


### PR DESCRIPTION
## Summary

External entries in rolldown configs now match deep imports automatically. Previously, listing `echarts` as external would externalize `import 'echarts'` but **not** `import 'echarts/core'` — so deep imports got bundled. Now both work.

### How it works

A new \`expandExternal()\` helper turns each string external into a regex that matches the bare package name OR any subpath. Applies to both:
- Auto-derived externals from \`package.json\` (\`dependencies\` + \`peerDependencies\`)
- User-supplied \`CONFIG.external\`

\`RegExp\` entries in \`CONFIG.external\` are passed through unchanged — power users keep full control.

### Examples

| External entry | Matches |
|---|---|
| \`echarts\` | \`echarts\`, \`echarts/core\`, \`echarts/charts/BarChart\` |
| \`@scope/pkg\` | \`@scope/pkg\`, \`@scope/pkg/sub\` |
| \`echarts\` | ❌ \`echartsjs\`, ❌ \`echarts-extension\` (correctly bounded) |

## Behavior change (minor bump)

Previously, only exact-match strings were externalized. If you relied on a package's deep imports being bundled while the bare import was external, you'll need to handle that explicitly now. In practice, almost no one does — this matches Vite's default behavior and what most users intuitively expect.

## Test plan

- [x] 7 new unit tests for \`expandExternal\` (deep matching, scoped pkgs, prefix collisions, regex passthrough, metachar escaping)
- [x] Updated 2 existing assertions to use new RegExp-aware helper
- [x] Full suite: 549 tests passing (up from 542)
- [x] Lint and typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)