### PR TITLE
fix(core,rolldown,rollup): three externals/config bug fixes

### DIFF
--- a/.changeset/core-externals-fixes.md
+++ b/.changeset/core-externals-fixes.md
@@ -1,0 +1,15 @@
+---
+'@vitus-labs/tools-core': patch
+'@vitus-labs/tools-rolldown': patch
+'@vitus-labs/tools-rollup': patch
+---
+
+Three bug fixes for build-time configuration handling. All three previously produced wrong-but-successful builds — externals not applied, bundles ballooning silently.
+
+**1. Throw on `vl-tools.config.mjs` load failure** — a malformed config (syntax error, throwing top-level code) used to print a stderr warning and silently fall back to defaults. Now throws with the file path and underlying parse error.
+
+**2. Subpath imports of declared deps now externalize** — listing `echarts` in dependencies/peerDependencies previously externalized the bare import only; `echarts/core`, `echarts/charts/BarChart`, etc. got bundled. Each declared dep is now expanded into a regex matching the bare name and any subpath. The `expandExternal` helper lives in `@vitus-labs/tools-core` and is reused by both `tools-rolldown` and `tools-rollup`.
+
+**3. `optionalDependencies` now externalized by default** — only `dependencies` + `peerDependencies` were considered before. Packages putting heavy renderers (pdfmake, docx, exceljs) in `optionalDependencies` ended up bundling them. If you actually want an optional dep bundled, move it to `dependencies`.
+
+The combined effect: declared deps in any of the three dep fields, including their subpaths, are now correctly externalized. The pre-existing `expandExternal` in `tools-rolldown` (added in v2.0.1) has been removed in favor of the canonical implementation in `tools-core`.

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -51,6 +51,12 @@ afterAll(() => {
   rmSync(BASE_TMP, { recursive: true, force: true })
 })
 
+const matchesExternal = (
+  externals: (string | RegExp)[] | undefined,
+  id: string,
+): boolean =>
+  (externals ?? []).some((e) => (typeof e === 'string' ? e === id : e.test(id)))
+
 describe('tools-core', () => {
   beforeEach(() => {
     vi.restoreAllMocks()
@@ -240,6 +246,26 @@ describe('tools-core', () => {
       expect(vlConfig('build').get('missing')).toEqual({})
     })
 
+    it('throws when vl-tools.config.mjs has a syntax error', async () => {
+      vi.resetModules()
+      testId++
+      const dir = path.join(BASE_TMP, `t${testId}`)
+      mkdirSync(dir, { recursive: true })
+      writeFileSync(
+        path.join(dir, 'package.json'),
+        JSON.stringify({ name: 'broken-pkg' }),
+      )
+      writeFileSync(
+        path.join(dir, 'vl-tools.config.mjs'),
+        'export default { broken: */ }',
+      )
+      vi.spyOn(process, 'cwd').mockReturnValue(dir)
+
+      await expect(import('./index.js')).rejects.toThrow(
+        /Failed to load config.*vl-tools\.config\.mjs/s,
+      )
+    })
+
     it('should cascade configs from root to package (deep merge)', async () => {
       vi.resetModules()
       const dir = createTestDir({
@@ -390,7 +416,7 @@ describe('tools-core', () => {
       const mod = await import('./index.js')
       expect(mod.PKG.name).toBe('@test/pkg')
       expect(mod.PKG.bundleName).toBe('testPkg')
-      expect(mod.PKG.externalDependencies).toContain('react')
+      expect(matchesExternal(mod.PKG.externalDependencies, 'react')).toBe(true)
     })
 
     it('should handle simple hyphenated package names in bundleName', async () => {
@@ -415,7 +441,57 @@ describe('tools-core', () => {
       vi.spyOn(process, 'cwd').mockReturnValue(dir)
 
       const mod = await import('./index.js')
-      expect(mod.PKG.externalDependencies).toContain('styled-components')
+      expect(
+        matchesExternal(mod.PKG.externalDependencies, 'styled-components'),
+      ).toBe(true)
+    })
+
+    it('should include optionalDependencies in externalDependencies', async () => {
+      vi.resetModules()
+      const dir = createTestDir({
+        packageJson: {
+          name: 'my-lib',
+          optionalDependencies: { pdfmake: '^0.2', docx: '^9' },
+        },
+      })
+      vi.spyOn(process, 'cwd').mockReturnValue(dir)
+
+      const mod = await import('./index.js')
+      expect(matchesExternal(mod.PKG.externalDependencies, 'pdfmake')).toBe(
+        true,
+      )
+      expect(matchesExternal(mod.PKG.externalDependencies, 'docx')).toBe(true)
+    })
+
+    it('should match deep imports of declared dependencies', async () => {
+      vi.resetModules()
+      const dir = createTestDir({
+        packageJson: {
+          name: '@test/pkg',
+          dependencies: { echarts: '^5', '@scope/pkg': '^1' },
+        },
+      })
+      vi.spyOn(process, 'cwd').mockReturnValue(dir)
+
+      const mod = await import('./index.js')
+      expect(matchesExternal(mod.PKG.externalDependencies, 'echarts')).toBe(
+        true,
+      )
+      expect(
+        matchesExternal(mod.PKG.externalDependencies, 'echarts/core'),
+      ).toBe(true)
+      expect(
+        matchesExternal(
+          mod.PKG.externalDependencies,
+          'echarts/charts/BarChart',
+        ),
+      ).toBe(true)
+      expect(
+        matchesExternal(mod.PKG.externalDependencies, '@scope/pkg/sub'),
+      ).toBe(true)
+      expect(
+        matchesExternal(mod.PKG.externalDependencies, 'echarts-extension'),
+      ).toBe(false)
     })
 
     it('should export VL_CONFIG as a function', async () => {
@@ -449,6 +525,64 @@ describe('tools-core', () => {
       const stories = mod.VL_CONFIG('stories')
       expect(stories.get('framework')).toBe('next')
       expect(stories.get('port')).toBe(3000)
+    })
+  })
+
+  describe('expandExternal', () => {
+    it('expands a bare package name to match deep imports', async () => {
+      vi.resetModules()
+      const dir = createTestDir({})
+      vi.spyOn(process, 'cwd').mockReturnValue(dir)
+      const mod = await import('./index.js')
+
+      const re = mod.expandExternal('echarts') as RegExp
+      expect(re.test('echarts')).toBe(true)
+      expect(re.test('echarts/core')).toBe(true)
+      expect(re.test('echarts/charts/BarChart')).toBe(true)
+    })
+
+    it('does not match unrelated packages with the same prefix', async () => {
+      vi.resetModules()
+      const dir = createTestDir({})
+      vi.spyOn(process, 'cwd').mockReturnValue(dir)
+      const mod = await import('./index.js')
+
+      const re = mod.expandExternal('echarts') as RegExp
+      expect(re.test('echartsjs')).toBe(false)
+      expect(re.test('echarts-extension')).toBe(false)
+    })
+
+    it('handles scoped packages', async () => {
+      vi.resetModules()
+      const dir = createTestDir({})
+      vi.spyOn(process, 'cwd').mockReturnValue(dir)
+      const mod = await import('./index.js')
+
+      const re = mod.expandExternal('@scope/pkg') as RegExp
+      expect(re.test('@scope/pkg')).toBe(true)
+      expect(re.test('@scope/pkg/sub')).toBe(true)
+      expect(re.test('@scope/pkg-extra')).toBe(false)
+    })
+
+    it('passes RegExp inputs through unchanged', async () => {
+      vi.resetModules()
+      const dir = createTestDir({})
+      vi.spyOn(process, 'cwd').mockReturnValue(dir)
+      const mod = await import('./index.js')
+
+      const original = /^foo$/
+      expect(mod.expandExternal(original)).toBe(original)
+    })
+
+    it('escapes regex metacharacters in package names', async () => {
+      vi.resetModules()
+      const dir = createTestDir({})
+      vi.spyOn(process, 'cwd').mockReturnValue(dir)
+      const mod = await import('./index.js')
+
+      const re = mod.expandExternal('foo.bar') as RegExp
+      expect(re.test('foo.bar')).toBe(true)
+      expect(re.test('fooXbar')).toBe(false)
     })
   })
 })

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -97,10 +97,9 @@ const loadModuleAsync = async (
     const mod = await import(pathToFileURL(filePath).href)
     return mod?.default ?? mod ?? {}
   } catch (e: any) {
-    console.warn(
+    throw new Error(
       `[tools-core] Failed to load config: ${filePath}\n  ${e.message}`,
     )
-    return {}
   }
 }
 
@@ -124,6 +123,17 @@ const getDependenciesList = (types: any) => {
   })
 
   return result
+}
+
+/**
+ * Convert a bare package name into a regex that matches the package itself
+ * AND any of its deep imports (e.g. `echarts` also matches `echarts/core`).
+ * Pass-through for RegExp inputs so users can override with their own pattern.
+ */
+const expandExternal = (id: string | RegExp): string | RegExp => {
+  if (id instanceof RegExp) return id
+  const escaped = id.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  return new RegExp(`^${escaped}(\\/|$)`)
 }
 
 // converts package name to umd or iife valid format
@@ -155,7 +165,8 @@ const getPkgData = (): Record<string, any> => {
     externalDependencies: getDependenciesList([
       'dependencies',
       'peerDependencies',
-    ]),
+      'optionalDependencies',
+    ]).map(expandExternal),
   }
 }
 
@@ -241,6 +252,7 @@ const TS_CONFIG = loadFileToJSON(TYPESCRIPT_FILE_NAME)
 
 export {
   defineConfig,
+  expandExternal,
   findFile,
   loadConfigParam,
   loadFileToJSON,

--- a/packages/mcp/src/resources/docs.ts
+++ b/packages/mcp/src/resources/docs.ts
@@ -36,7 +36,7 @@ export default defineConfig({
 ### PKG
 Parsed package.json with computed properties:
 - bundleName — camelCase package name
-- externalDependencies — merged dependencies + peerDependencies
+- externalDependencies — merged dependencies + peerDependencies + optionalDependencies, each expanded to a regex matching the bare package name and any subpath (e.g. \`echarts\` matches \`echarts/core\`)
 
 ### VL_CONFIG
 Config from vl-tools.config.mjs:

--- a/packages/rolldown/src/rolldown/config.test.ts
+++ b/packages/rolldown/src/rolldown/config.test.ts
@@ -12,6 +12,11 @@ vi.mock('rollup-plugin-visualizer', () => ({
 vi.mock('@vitus-labs/tools-core', () => ({
   swapGlobals: (globals: Record<string, string>) =>
     Object.fromEntries(Object.entries(globals).map(([k, v]) => [v, k])),
+  expandExternal: (id: string | RegExp): string | RegExp => {
+    if (id instanceof RegExp) return id
+    const escaped = id.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    return new RegExp(`^${escaped}(\\/|$)`)
+  },
 }))
 
 const { mockConfig, mockPKG } = vi.hoisted(() => ({
@@ -42,7 +47,7 @@ vi.mock('../config/index.js', () => ({
   PLATFORMS: ['browser', 'node', 'web', 'native'],
 }))
 
-import rolldownConfig, { buildDts, expandExternal } from './config.js'
+import rolldownConfig, { buildDts } from './config.js'
 
 const defaultConfig = { ...mockConfig }
 const defaultPKG = { ...mockPKG }
@@ -350,39 +355,6 @@ describe('buildDts', () => {
 
     expect(result?.output.dir).toBe('.')
     expect(result?.output.entryFileNames).toBe('index.d.ts')
-  })
-})
-
-describe('expandExternal', () => {
-  it('expands a bare package name to match deep imports', () => {
-    const re = expandExternal('echarts') as RegExp
-    expect(re.test('echarts')).toBe(true)
-    expect(re.test('echarts/core')).toBe(true)
-    expect(re.test('echarts/charts/BarChart')).toBe(true)
-  })
-
-  it('does not match unrelated packages with the same prefix', () => {
-    const re = expandExternal('echarts') as RegExp
-    expect(re.test('echartsjs')).toBe(false)
-    expect(re.test('echarts-extension')).toBe(false)
-  })
-
-  it('handles scoped packages', () => {
-    const re = expandExternal('@scope/pkg') as RegExp
-    expect(re.test('@scope/pkg')).toBe(true)
-    expect(re.test('@scope/pkg/sub')).toBe(true)
-    expect(re.test('@scope/other')).toBe(false)
-  })
-
-  it('passes RegExp inputs through unchanged', () => {
-    const original = /^foo$/
-    expect(expandExternal(original)).toBe(original)
-  })
-
-  it('escapes regex metacharacters in package names', () => {
-    const re = expandExternal('foo.bar') as RegExp
-    expect(re.test('foo.bar')).toBe(true)
-    expect(re.test('fooXbar')).toBe(false)
   })
 })
 

--- a/packages/rolldown/src/rolldown/config.ts
+++ b/packages/rolldown/src/rolldown/config.ts
@@ -1,21 +1,10 @@
 import { existsSync } from 'node:fs'
-import { swapGlobals } from '@vitus-labs/tools-core'
+import { expandExternal, swapGlobals } from '@vitus-labs/tools-core'
 import type { RolldownPlugin } from 'rolldown'
 import { dts } from 'rolldown-plugin-dts'
 import filesize from 'rollup-plugin-filesize'
 import { visualizer } from 'rollup-plugin-visualizer'
 import { CONFIG, PKG, PLATFORMS } from '../config/index.js'
-
-/**
- * Convert a bare package name into a regex that matches the package itself
- * AND any of its deep imports (e.g. `echarts` also matches `echarts/core`).
- * Pass-through for RegExp inputs.
- */
-const expandExternal = (id: string | RegExp): string | RegExp => {
-  if (id instanceof RegExp) return id
-  const escaped = id.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-  return new RegExp(`^${escaped}(\\/.*)?$`)
-}
 
 const resolveExternals = (): (string | RegExp)[] =>
   CONFIG.bundleAll
@@ -237,4 +226,4 @@ const buildAllDts = (): ReturnType<typeof createDtsConfig>[] => {
 }
 
 export default rolldownConfig
-export { buildAllDts, buildDts, expandExternal }
+export { buildAllDts, buildDts }

--- a/packages/rollup/src/rollup/config.test.ts
+++ b/packages/rollup/src/rollup/config.test.ts
@@ -59,6 +59,11 @@ vi.mock('node:module', () => ({
 vi.mock('@vitus-labs/tools-core', () => ({
   swapGlobals: (globals: Record<string, string>) =>
     Object.fromEntries(Object.entries(globals).map(([k, v]) => [v, k])),
+  expandExternal: (id: string | RegExp): string | RegExp => {
+    if (id instanceof RegExp) return id
+    const escaped = id.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    return new RegExp(`^${escaped}(\\/|$)`)
+  },
 }))
 
 vi.mock('../config/index.js', () => ({
@@ -71,6 +76,12 @@ import rollupConfig from './config.js'
 
 const defaultConfig = { ...mockConfig }
 const defaultPKG = { ...mockPKG }
+
+const matchesExternal = (
+  externals: (string | RegExp)[] | undefined,
+  id: string,
+): boolean =>
+  (externals ?? []).some((e) => (typeof e === 'string' ? e === id : e.test(id)))
 
 describe('rollupConfig', () => {
   beforeEach(() => {
@@ -91,8 +102,9 @@ describe('rollupConfig', () => {
     expect(config.output.file).toBe('lib/index.js')
     expect(config.output.format).toBe('es')
     expect(config.output.sourcemap).toBe(true)
-    expect(config.external).toContain('react')
-    expect(config.external).toContain('react/jsx-runtime')
+    expect(matchesExternal(config.external, 'react')).toBe(true)
+    expect(matchesExternal(config.external, 'react/jsx-runtime')).toBe(true)
+    expect(matchesExternal(config.external, 'react/jsx-dev-runtime')).toBe(true)
   })
 
   it('should set named exports for CJS format', () => {

--- a/packages/rollup/src/rollup/config.ts
+++ b/packages/rollup/src/rollup/config.ts
@@ -2,7 +2,7 @@ import { createRequire } from 'node:module'
 import { nodeResolve } from '@rollup/plugin-node-resolve'
 import replace from '@rollup/plugin-replace'
 import terser from '@rollup/plugin-terser'
-import { swapGlobals } from '@vitus-labs/tools-core'
+import { expandExternal, swapGlobals } from '@vitus-labs/tools-core'
 import { apiExtractor } from 'rollup-plugin-api-extractor'
 import filesize from 'rollup-plugin-filesize'
 import typescript from 'rollup-plugin-typescript2'
@@ -166,7 +166,9 @@ const rollupConfig = ({
       interop: 'compat',
       systemNullSetters: false,
     },
-    external: [...PKG.externalDependencies, ...CONFIG.external],
+    external: [...PKG.externalDependencies, ...CONFIG.external].map(
+      expandExternal,
+    ),
     treeshake: {
       moduleSideEffects: false,
       propertyReadSideEffects: false,


### PR DESCRIPTION
## Summary

Bundles all 3 issues from the externals/config plan into one PR.

### 1. tools-core: throw on \`vl-tools.config.mjs\` load failure

A malformed config (syntax error, throwing top-level code) previously printed a stderr warning and silently fell back to default config — producing wrong-but-successful builds. Now throws with the file path and underlying parse error.

### 2. tools-core / tools-rollup: subpath imports of declared deps now externalize

Listing \`echarts\` in \`dependencies\`/\`peerDependencies\` previously externalized the bare import only — \`echarts/core\`, \`echarts/charts/BarChart\` got bundled. Each declared dep is now expanded into a regex matching the bare name and any subpath. The \`expandExternal\` helper lives in \`@vitus-labs/tools-core\` and is reused by both \`tools-rolldown\` and \`tools-rollup\`.

The local \`expandExternal\` added to \`tools-rolldown\` in 2.0.1 is removed in favor of the canonical implementation in \`tools-core\`.

### 3. tools-core: \`optionalDependencies\` externalized by default

Only \`dependencies\` + \`peerDependencies\` were considered before. Packages putting heavy renderers (pdfmake, docx, exceljs) in \`optionalDependencies\` ended up bundling them (~14 MB). If you actually want an optional dep bundled, move it to \`dependencies\`.

## Versioning

- \`@vitus-labs/tools-core\`: **patch** (2.0.0 → 2.0.1)
- \`@vitus-labs/tools-rolldown\`: **patch** (2.1.0 → 2.1.1) — internal refactor
- \`@vitus-labs/tools-rollup\`: **patch** (2.0.0 → 2.0.1) — gains deep-import externalization

All 3 are surfacing/fixing wrong-build-output behavior, not changing intentional contracts.

## Test plan

- [x] All 552 tests pass (was 542 pre-PR — 10 new tests across core/rolldown/rollup)
- [x] Lint and typecheck clean
- [x] All 10 packages build
- [x] Rolldown integration test still passes (fixture builds correctly with new core helper)

🤖 Generated with [Claude Code](https://claude.com/claude-code)