### PR TITLE
ci(release): use RELEASE_PAT for Version PR creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,9 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # PAT lets the resulting Version PR trigger CI workflows.
+          # GITHUB_TOKEN-created PRs don't (anti-recursion safeguard).
+          token: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
@@ -61,7 +63,7 @@ jobs:
           title: 'chore: version packages'
           commit: 'chore: version packages'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
 
   # ── Prerelease (feature/release branches) ───────────────────────
   prerelease:


### PR DESCRIPTION
## Summary

Fixes the recurring "Version Packages PR has no CI checks" deadlock.

GitHub blocks workflows from triggering on PRs created using \`GITHUB_TOKEN\` (anti-recursion safeguard). Combined with the branch protection rule requiring CI green to merge, every release requires manually closing and reopening the Version PR to unstick CI.

Switching to a PAT for the changesets-action makes the Version PR appear as user-authored, so workflows trigger normally.

## What changes

\`release.yml\` two lines:

\`\`\`diff
- token: \${{ secrets.GITHUB_TOKEN }}
+ token: \${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
\`\`\`

\`\`\`diff
- GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
+ GITHUB_TOKEN: \${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
\`\`\`

The \`||\` fallback means the workflow keeps working even before the secret exists — no breakage if you merge this before adding the PAT.

## Action required (after merge)

Create a fine-grained PAT and add it as repo secret \`RELEASE_PAT\`:

1. github.com/settings/personal-access-tokens → New token (fine-grained)
2. Repository access: only this repo
3. Repository permissions:
   - **Contents**: Read and write
   - **Pull requests**: Read and write
4. Save token, add to repo Settings → Secrets and variables → Actions → New repository secret
5. Name: \`RELEASE_PAT\`, Value: the token

After that, the next Version PR will run CI normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)