### PR TITLE
feat(typescript): add node preset and restore lib to Bundler

### DIFF
--- a/.changeset/typescript-node-preset.md
+++ b/.changeset/typescript-node-preset.md
@@ -1,0 +1,22 @@
+---
+'@vitus-labs/tools-typescript': minor
+---
+
+Add a `node` tsconfig preset and revert `lib` back to `Bundler` resolution.
+
+```json
+// For libraries bundled by rolldown/rollup/etc — what most consumers want:
+{ "extends": "@vitus-labs/tools-typescript/lib" }
+
+// For server/CLI packages built with plain tsc and consumed as Node ESM:
+{ "extends": "@vitus-labs/tools-typescript/node" }
+```
+
+**Why**: 2.2.0 (#119) over-corrected by switching `lib` to `NodeNext` to surface a runtime ESM bug in two packages. But `Bundler` is the TS team's recommended setting for code that goes through a bundler — which is most "library" use cases. The right architecture is two presets:
+
+- **`lib` (Bundler, restored)** — for libraries that get bundled. Permissive about extensions because the bundler resolves them. Has DOM + jsx.
+- **`node` (NodeNext + rewriteRelativeImportExtensions, new)** — for pure Node packages. Strict about extensions because Node's resolver is. No DOM, no jsx, no allowJs.
+
+The `nextjs` preset is unchanged.
+
+If your package is bundled before consumers see it, use `lib`. If it ships raw `.js` that Node loads directly (like every package in this monorepo), use `node` — the strictness catches the missing-extension bug class at build time.

--- a/packages/atlas/tsconfig.json
+++ b/packages/atlas/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@vitus-labs/tools-typescript/lib",
+  "extends": "@vitus-labs/tools-typescript/node",
   "compilerOptions": {
     "noEmit": false,
     "outDir": "lib",

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@vitus-labs/tools-typescript/lib",
+  "extends": "@vitus-labs/tools-typescript/node",
   "compilerOptions": {
     "noEmit": false,
     "outDir": "lib",

--- a/packages/favicon/tsconfig.json
+++ b/packages/favicon/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@vitus-labs/tools-typescript/lib",
+  "extends": "@vitus-labs/tools-typescript/node",
   "compilerOptions": {
     "noEmit": false,
     "outDir": "lib",

--- a/packages/mcp/tsconfig.json
+++ b/packages/mcp/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@vitus-labs/tools-typescript/lib",
+  "extends": "@vitus-labs/tools-typescript/node",
   "compilerOptions": {
     "noEmit": false,
     "outDir": "lib",

--- a/packages/nextjs-images/tsconfig.json
+++ b/packages/nextjs-images/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@vitus-labs/tools-typescript/lib",
+  "extends": "@vitus-labs/tools-typescript/node",
   "compilerOptions": {
     "noEmit": false,
     "outDir": "lib",

--- a/packages/nextjs/tsconfig.json
+++ b/packages/nextjs/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@vitus-labs/tools-typescript/lib",
+  "extends": "@vitus-labs/tools-typescript/node",
   "compilerOptions": {
     "noEmit": false,
     "outDir": "lib",

--- a/packages/rolldown/tsconfig.json
+++ b/packages/rolldown/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@vitus-labs/tools-typescript/lib",
+  "extends": "@vitus-labs/tools-typescript/node",
   "compilerOptions": {
     "noEmit": false,
     "outDir": "lib",

--- a/packages/rollup/tsconfig.json
+++ b/packages/rollup/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@vitus-labs/tools-typescript/lib",
+  "extends": "@vitus-labs/tools-typescript/node",
   "compilerOptions": {
     "noEmit": false,
     "outDir": "lib",

--- a/packages/storybook/tsconfig.json
+++ b/packages/storybook/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@vitus-labs/tools-typescript/lib",
+  "extends": "@vitus-labs/tools-typescript/node",
   "compilerOptions": {
     "noEmit": false,
     "outDir": "lib",

--- a/packages/typescript/__tests__/tsconfig-presets.test.ts
+++ b/packages/typescript/__tests__/tsconfig-presets.test.ts
@@ -18,16 +18,16 @@ describe('lib.json', () => {
     expect(config.compilerOptions.target).toBe('ES2024')
   })
 
-  it('should use module NodeNext', () => {
-    expect(config.compilerOptions.module).toBe('NodeNext')
+  it('should use module Preserve', () => {
+    expect(config.compilerOptions.module).toBe('Preserve')
   })
 
-  it('should use NodeNext module resolution', () => {
-    expect(config.compilerOptions.moduleResolution).toBe('NodeNext')
+  it('should use Bundler module resolution (best practice for bundled libs)', () => {
+    expect(config.compilerOptions.moduleResolution).toBe('Bundler')
   })
 
-  it('should rewrite relative import extensions on emit', () => {
-    expect(config.compilerOptions.rewriteRelativeImportExtensions).toBe(true)
+  it('should include dom in lib (browser/SSR libs)', () => {
+    expect(config.compilerOptions.lib).toContain('dom')
   })
 
   it('should have strict mode enabled', () => {
@@ -41,6 +41,46 @@ describe('lib.json', () => {
   it('should enable declaration and sourceMap', () => {
     expect(config.compilerOptions.declaration).toBe(true)
     expect(config.compilerOptions.sourceMap).toBe(true)
+  })
+})
+
+describe('node.json', () => {
+  const config = loadJson('node.json')
+
+  it('should have a valid $schema', () => {
+    expect(config.$schema).toMatch(/tsconfig/)
+  })
+
+  it('should use module NodeNext', () => {
+    expect(config.compilerOptions.module).toBe('NodeNext')
+  })
+
+  it('should use NodeNext module resolution', () => {
+    expect(config.compilerOptions.moduleResolution).toBe('NodeNext')
+  })
+
+  it('should rewrite relative import extensions on emit', () => {
+    expect(config.compilerOptions.rewriteRelativeImportExtensions).toBe(true)
+  })
+
+  it('should not include dom in lib (server-only)', () => {
+    expect(config.compilerOptions.lib).toEqual(['ES2024'])
+  })
+
+  it('should not configure jsx (server-only)', () => {
+    expect(config.compilerOptions.jsx).toBeUndefined()
+  })
+
+  it('should not allow JS interop (TS-only)', () => {
+    expect(config.compilerOptions.allowJs).toBeUndefined()
+  })
+
+  it('should include node types', () => {
+    expect(config.compilerOptions.types).toEqual(['node'])
+  })
+
+  it('should have strict mode enabled', () => {
+    expect(config.compilerOptions.strict).toBe(true)
   })
 })
 

--- a/packages/typescript/node.json
+++ b/packages/typescript/node.json
@@ -2,18 +2,17 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
     "target": "ES2024",
-    "module": "Preserve",
-    "moduleResolution": "Bundler",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "rewriteRelativeImportExtensions": true,
     "moduleDetection": "force",
     "verbatimModuleSyntax": true,
-    "jsx": "react-jsx",
-    "lib": ["ES2024", "dom"],
+    "lib": ["ES2024"],
     "types": ["node"],
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
     "resolveJsonModule": true,
-    "allowJs": true,
     "strict": true,
     "noUncheckedIndexedAccess": true,
     "declaration": true,
@@ -23,5 +22,5 @@
     "noEmit": true
   },
   "include": ["src"],
-  "exclude": ["node_modules", "__stories__", "lib"]
+  "exclude": ["node_modules", "lib"]
 }

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -14,11 +14,13 @@
   "type": "module",
   "exports": {
     "./lib": "./lib.json",
+    "./node": "./node.json",
     "./nextjs": "./nextjs.json",
     "./package.json": "./package.json"
   },
   "files": [
     "lib.json",
+    "node.json",
     "nextjs.json"
   ],
   "engines": {

--- a/packages/vitest/tsconfig.json
+++ b/packages/vitest/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@vitus-labs/tools-typescript/lib",
+  "extends": "@vitus-labs/tools-typescript/node",
   "compilerOptions": {
     "noEmit": false,
     "outDir": "lib",


### PR DESCRIPTION
## Summary

Splits the tsconfig presets so each one matches its actual best-practice config:

| Preset | Resolution | Use for |
|---|---|---|
| \`lib\` (restored to Bundler) | \`Bundler\` | Libraries bundled by rolldown/rollup/etc — the bundler resolves imports |
| \`node\` (new) | \`NodeNext\` + \`rewriteRelativeImportExtensions\` | Pure Node packages built with plain tsc, consumed as Node ESM |
| \`nextjs\` | unchanged | Next.js apps |

## Context

#119 (2.2.0) switched \`lib\` to \`NodeNext\` to surface the missing-extension bug class. But \`Bundler\` is what the TS team explicitly recommends for code that goes through a bundler — which is most \"library\" use cases. The bundler handles extension resolution; tightening to NodeNext was the wrong default for that audience.

Right architecture: keep both. \`lib\` for the bundled-library case (Bundler is permissive, that's fine — the bundler does the work). \`node\` for the strict-Node-ESM case (NodeNext catches missing extensions at compile time).

## Migration applied to this monorepo

All 10 packages in this monorepo build with plain \`tsc\` and ship raw \`.js\` consumed by Node — that's the \`node\` use case, not \`lib\`. So every \`packages/*/tsconfig.json\` switches:

\`\`\`diff
- \"extends\": \"@vitus-labs/tools-typescript/lib\"
+ \"extends\": \"@vitus-labs/tools-typescript/node\"
\`\`\`

Source files don't change — they're already on the \`.ts\`-extension convention from #119, which \`node\` preserves.

## Verification

- ✅ All 563 tests pass (was 554, +9 for new \`node.json\` preset assertions and updated \`lib.json\` ones)
- ✅ All 10 packages build
- ✅ Lint and typecheck clean
- ✅ Every built lib resolves cleanly under Node ESM (smoke-tested)

## Versioning

\`@vitus-labs/tools-typescript\`: **minor** — adds new \`node\` preset, restores \`lib\` to its pre-#119 best-practice config.

Per the \`fixed\` group, all 12 packages will land at the next minor (likely 2.3.0).

## Migration for consumers

If your package gets bundled (rolldown/rollup/vite/webpack/esbuild) before consumers see it: keep \`extends: \"@vitus-labs/tools-typescript/lib\"\`. The strictness from 2.2.0 is rolled back — \`.js\`-in-source still works, \`.ts\`-in-source no longer rewrites (because Bundler doesn't enable it).

If your package ships raw \`.js\` for Node to consume directly: switch to \`extends: \"@vitus-labs/tools-typescript/node\"\`. Get the strictness back, plus the \`.ts\`-in-source convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)