### PR TITLE
fix(atlas,rolldown,rollup): audit — scanner syscalls, temp-dir leak, drop rimraf

### DIFF
--- a/.changeset/audit-syscalls-tempdir-rimraf.md
+++ b/.changeset/audit-syscalls-tempdir-rimraf.md
@@ -1,0 +1,15 @@
+---
+'@vitus-labs/tools-atlas': patch
+'@vitus-labs/tools-rolldown': patch
+'@vitus-labs/tools-rollup': patch
+---
+
+Audit fixes — three proven issues, each measured and regression-tested.
+
+**1. atlas: scanner N+1 `statSync` (perf)** — `listDirectories` called `statSync` once per directory entry. Now uses `readdirSync(base, { withFileTypes: true })` and only falls back to `statSync` for symbolic links (which `Dirent.isDirectory()` can't resolve). Measured on a 65-entry workspace: **65 → 5 syscalls (92% fewer)**, identical directory output including symlinked package dirs (regression-tested).
+
+**2. rolldown: temp-dir leak on error path (resource leak)** — `buildDtsIsolated` removed its `__dts_tmp_*` directory only on the success path. If the DTS build or any post-processing step threw, the temp dir leaked into `lib/` and shipped in the published package (`files: ["lib"]`). Cleanup is now in a `finally` block. Proven by a test that fails on the old code (0 cleanup calls) and passes after.
+
+**3. rolldown + rollup: drop the `rimraf` dependency** — both packages require Node ≥ 22, where the built-in `fs.rmSync(path, { recursive: true, force: true })` does exactly what `rimraf.sync` did. Removed `rimraf` as a direct dependency from both packages — one fewer runtime dependency and supply-chain surface, zero behavior change.
+
+No memory leaks were found. Four separately-reported correctness concerns (depth-map inversion, cycle self-loop handling, bundle-size I/O, transitive-size dedup) were investigated and disproven by tracing the actual code — no changes made there.

--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,7 @@
     },
     "packages/atlas": {
       "name": "@vitus-labs/tools-atlas",
-      "version": "2.0.0",
+      "version": "2.3.0",
       "bin": {
         "vl_atlas": "./lib/bin/run-atlas.js",
       },
@@ -42,7 +42,7 @@
     },
     "packages/core": {
       "name": "@vitus-labs/tools-core",
-      "version": "2.0.0",
+      "version": "2.3.0",
       "devDependencies": {
         "@types/node": "^25.6.0",
         "@vitus-labs/tools-typescript": "workspace:^",
@@ -51,7 +51,7 @@
     },
     "packages/favicon": {
       "name": "@vitus-labs/tools-favicon",
-      "version": "2.0.0",
+      "version": "2.3.0",
       "bin": {
         "vl_favicon": "./lib/bin/run-favicon.js",
       },
@@ -67,7 +67,7 @@
     },
     "packages/mcp": {
       "name": "@vitus-labs/tools-mcp",
-      "version": "2.0.0",
+      "version": "2.3.0",
       "bin": {
         "vl_mcp": "./lib/bin/serve.js",
       },
@@ -84,7 +84,7 @@
     },
     "packages/nextjs": {
       "name": "@vitus-labs/tools-nextjs",
-      "version": "2.0.0",
+      "version": "2.3.0",
       "dependencies": {
         "@vitus-labs/tools-core": "workspace:^",
       },
@@ -100,7 +100,7 @@
     },
     "packages/nextjs-images": {
       "name": "@vitus-labs/tools-nextjs-images",
-      "version": "2.0.0",
+      "version": "2.3.0",
       "dependencies": {
         "chalk": "^5.6.2",
         "file-loader": "^6.2.0",
@@ -120,7 +120,7 @@
     },
     "packages/rolldown": {
       "name": "@vitus-labs/tools-rolldown",
-      "version": "2.0.0",
+      "version": "2.3.0",
       "bin": {
         "vl_rolldown_build": "./lib/bin/run-build.js",
         "vl_rolldown_build-watch": "./lib/bin/run-watch.js",
@@ -128,7 +128,6 @@
       "dependencies": {
         "@vitus-labs/tools-core": "workspace:^",
         "chalk": "^5.6.2",
-        "rimraf": "^6.1.3",
         "rolldown": "^1.0.0-rc.17",
         "rolldown-plugin-dts": "^0.23.2",
         "rollup-plugin-filesize": "^10.0.0",
@@ -142,7 +141,7 @@
     },
     "packages/rollup": {
       "name": "@vitus-labs/tools-rollup",
-      "version": "2.0.0",
+      "version": "2.3.0",
       "bin": {
         "vl_build": "./lib/bin/run-build.js",
         "vl_build-watch": "./lib/bin/run-watch.js",
@@ -158,7 +157,6 @@
         "chalk": "^5.6.2",
         "find-up": "^8.0.0",
         "lodash-es": "^4.18.1",
-        "rimraf": "^6.1.3",
         "rollup": "^4.60.2",
         "rollup-plugin-api-extractor": "^0.2.5",
         "rollup-plugin-filesize": "^10.0.0",
@@ -178,7 +176,7 @@
     },
     "packages/storybook": {
       "name": "@vitus-labs/tools-storybook",
-      "version": "2.0.0",
+      "version": "2.3.0",
       "bin": {
         "vl_stories": "./lib/bin/run-stories.js",
         "vl_stories-build": "./lib/bin/run-stories-build.js",
@@ -221,14 +219,14 @@
     },
     "packages/typescript": {
       "name": "@vitus-labs/tools-typescript",
-      "version": "2.0.0",
+      "version": "2.3.0",
       "peerDependencies": {
         "typescript": "^6.0.3",
       },
     },
     "packages/vitest": {
       "name": "@vitus-labs/tools-vitest",
-      "version": "2.0.0",
+      "version": "2.3.0",
       "devDependencies": {
         "@vitus-labs/tools-typescript": "workspace:^",
         "typescript": "^6.0.3",
@@ -1589,7 +1587,7 @@
 
     "loupe": ["loupe@3.2.1", "", {}, "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ=="],
 
-    "lru-cache": ["lru-cache@11.2.5", "", {}, "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw=="],
+    "lru-cache": ["lru-cache@7.18.3", "", {}, "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="],
 
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 
@@ -1665,7 +1663,7 @@
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
-    "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
+    "minipass": ["minipass@5.0.0", "", {}, "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ=="],
 
     "minipass-collect": ["minipass-collect@1.0.2", "", { "dependencies": { "minipass": "^3.0.0" } }, "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA=="],
 
@@ -1911,7 +1909,7 @@
 
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 
-    "rimraf": ["rimraf@6.1.3", "", { "dependencies": { "glob": "^13.0.3", "package-json-from-dist": "^1.0.1" }, "bin": { "rimraf": "dist/esm/bin.mjs" } }, "sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA=="],
+    "rimraf": ["rimraf@3.0.2", "", { "dependencies": { "glob": "^7.1.3" }, "bin": { "rimraf": "bin.js" } }, "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA=="],
 
     "rolldown": ["rolldown@1.0.0-rc.17", "", { "dependencies": { "@oxc-project/types": "=0.127.0", "@rolldown/pluginutils": "1.0.0-rc.17" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.17", "@rolldown/binding-darwin-arm64": "1.0.0-rc.17", "@rolldown/binding-darwin-x64": "1.0.0-rc.17", "@rolldown/binding-freebsd-x64": "1.0.0-rc.17", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA=="],
 
@@ -2323,11 +2321,7 @@
 
     "@microsoft/api-extractor/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
-    "@npmcli/git/lru-cache": ["lru-cache@7.18.3", "", {}, "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="],
-
     "@npmcli/git/which": ["which@3.0.1", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "bin/which.js" } }, "sha512-XA1b62dzQzLfaEOSQFTCOd5KFf/1VSzZo7/7TUjnya6u0vGGKzU96UQBZTAThCb2j4/xjBAyii1OhRLJEivHvg=="],
-
-    "@npmcli/move-file/rimraf": ["rimraf@3.0.2", "", { "dependencies": { "glob": "^7.1.3" }, "bin": { "rimraf": "bin.js" } }, "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA=="],
 
     "@npmcli/promise-spawn/which": ["which@3.0.1", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "bin/which.js" } }, "sha512-XA1b62dzQzLfaEOSQFTCOd5KFf/1VSzZo7/7TUjnya6u0vGGKzU96UQBZTAThCb2j4/xjBAyii1OhRLJEivHvg=="],
 
@@ -2403,8 +2397,6 @@
 
     "cacache/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
 
-    "cacache/lru-cache": ["lru-cache@7.18.3", "", {}, "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="],
-
     "cacache/minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
 
     "cacache/p-map": ["p-map@4.0.0", "", { "dependencies": { "aggregate-error": "^3.0.0" } }, "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ=="],
@@ -2416,8 +2408,6 @@
     "chromium-edge-launcher/@types/node": ["@types/node@25.3.5", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA=="],
 
     "chromium-edge-launcher/is-wsl": ["is-wsl@2.2.0", "", { "dependencies": { "is-docker": "^2.0.0" } }, "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww=="],
-
-    "chromium-edge-launcher/rimraf": ["rimraf@3.0.2", "", { "dependencies": { "glob": "^7.1.3" }, "bin": { "rimraf": "bin.js" } }, "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA=="],
 
     "cliui/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
@@ -2449,13 +2439,13 @@
 
     "glob/minimatch": ["minimatch@10.2.2", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw=="],
 
+    "glob/minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
+
     "global-prefix/which": ["which@4.0.0", "", { "dependencies": { "isexe": "^3.1.1" }, "bin": { "node-which": "bin/which.js" } }, "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg=="],
 
     "gzip-size/duplexer": ["duplexer@0.1.2", "", {}, "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg=="],
 
     "hoist-non-react-statics/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
-
-    "hosted-git-info/lru-cache": ["lru-cache@7.18.3", "", {}, "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="],
 
     "ignore-walk/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 
@@ -2502,10 +2492,6 @@
     "magicast/@babel/parser": ["@babel/parser@7.29.0", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww=="],
 
     "magicast/@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
-
-    "make-fetch-happen/lru-cache": ["lru-cache@7.18.3", "", {}, "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="],
-
-    "make-fetch-happen/minipass": ["minipass@5.0.0", "", {}, "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ=="],
 
     "make-fetch-happen/negotiator": ["negotiator@0.6.4", "", {}, "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w=="],
 
@@ -2573,11 +2559,9 @@
 
     "node-gyp/make-fetch-happen": ["make-fetch-happen@10.2.1", "", { "dependencies": { "agentkeepalive": "^4.2.1", "cacache": "^16.1.0", "http-cache-semantics": "^4.1.0", "http-proxy-agent": "^5.0.0", "https-proxy-agent": "^5.0.0", "is-lambda": "^1.0.1", "lru-cache": "^7.7.1", "minipass": "^3.1.6", "minipass-collect": "^1.0.2", "minipass-fetch": "^2.0.3", "minipass-flush": "^1.0.5", "minipass-pipeline": "^1.2.4", "negotiator": "^0.6.3", "promise-retry": "^2.0.1", "socks-proxy-agent": "^7.0.0", "ssri": "^9.0.0" } }, "sha512-NgOPbRiaQM10DYXvN3/hhGVI2M5MtITFryzBGxHM5p4wnFxsVCbxkrBrDsk+EZ5OB4jEOT7AjDxtdF+KVEFT7w=="],
 
-    "node-gyp/rimraf": ["rimraf@3.0.2", "", { "dependencies": { "glob": "^7.1.3" }, "bin": { "rimraf": "bin.js" } }, "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA=="],
+    "path-scurry/lru-cache": ["lru-cache@11.2.5", "", {}, "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw=="],
 
-    "npm-registry-fetch/minipass": ["minipass@5.0.0", "", {}, "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ=="],
-
-    "pacote/minipass": ["minipass@5.0.0", "", {}, "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ=="],
+    "path-scurry/minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
     "pkg-dir/find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
 
@@ -2613,6 +2597,8 @@
 
     "redent/strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "^1.0.0" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
 
+    "rimraf/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
+
     "rollup-plugin-api-extractor/@microsoft/api-extractor": ["@microsoft/api-extractor@7.56.2", "", { "dependencies": { "@microsoft/api-extractor-model": "7.32.2", "@microsoft/tsdoc": "~0.16.0", "@microsoft/tsdoc-config": "~0.18.0", "@rushstack/node-core-library": "5.19.1", "@rushstack/rig-package": "0.6.0", "@rushstack/terminal": "0.21.0", "@rushstack/ts-command-line": "5.2.0", "diff": "~8.0.2", "lodash": "~4.17.15", "minimatch": "10.1.2", "resolve": "~1.22.1", "semver": "~7.5.4", "source-map": "~0.6.1", "typescript": "5.8.2" }, "bin": { "api-extractor": "bin/api-extractor" } }, "sha512-d94f7S+H43jDxY/YIyp5UOE9N12HZmEPP5Ct96us+fw1FVKBoy4itTopdVM1VrcpduuA7fK/t31CgA2jM8AqSA=="],
 
     "rollup-plugin-typescript2/@rollup/pluginutils": ["@rollup/pluginutils@4.2.1", "", { "dependencies": { "estree-walker": "^2.0.1", "picomatch": "^2.2.2" } }, "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ=="],
@@ -2640,8 +2626,6 @@
     "storybook/open": ["open@10.2.0", "", { "dependencies": { "default-browser": "^5.2.1", "define-lazy-prop": "^3.0.0", "is-inside-container": "^1.0.0", "wsl-utils": "^0.1.0" } }, "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA=="],
 
     "tar/fs-minipass": ["fs-minipass@2.1.0", "", { "dependencies": { "minipass": "^3.0.0" } }, "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg=="],
-
-    "tar/minipass": ["minipass@5.0.0", "", {}, "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ=="],
 
     "terser/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
 
@@ -2733,8 +2717,6 @@
 
     "@manypkg/get-packages/fs-extra/jsonfile": ["jsonfile@4.0.0", "", { "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg=="],
 
-    "@npmcli/move-file/rimraf/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
-
     "@react-native/codegen/@babel/parser/@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
 
     "@react-native/codegen/tinyglobby/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
@@ -2798,8 +2780,6 @@
     "chromium-edge-launcher/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "chromium-edge-launcher/is-wsl/is-docker": ["is-docker@2.2.1", "", { "bin": { "is-docker": "cli.js" } }, "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="],
-
-    "chromium-edge-launcher/rimraf/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
     "cliui/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
@@ -2927,8 +2907,6 @@
 
     "node-gyp/make-fetch-happen/cacache": ["cacache@16.1.3", "", { "dependencies": { "@npmcli/fs": "^2.1.0", "@npmcli/move-file": "^2.0.0", "chownr": "^2.0.0", "fs-minipass": "^2.1.0", "glob": "^8.0.1", "infer-owner": "^1.0.4", "lru-cache": "^7.7.1", "minipass": "^3.1.6", "minipass-collect": "^1.0.2", "minipass-flush": "^1.0.5", "minipass-pipeline": "^1.2.4", "mkdirp": "^1.0.4", "p-map": "^4.0.0", "promise-inflight": "^1.0.1", "rimraf": "^3.0.2", "ssri": "^9.0.0", "tar": "^6.1.11", "unique-filename": "^2.0.0" } }, "sha512-/+Emcj9DAXxX4cwlLmRI9c166RuL3w30zp4R7Joiv2cQTtTtA+jeuCAjH3ZlGnYS3tKENSrKhAzVVP9GVyzeYQ=="],
 
-    "node-gyp/make-fetch-happen/lru-cache": ["lru-cache@7.18.3", "", {}, "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="],
-
     "node-gyp/make-fetch-happen/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
 
     "node-gyp/make-fetch-happen/minipass-fetch": ["minipass-fetch@2.1.2", "", { "dependencies": { "minipass": "^3.1.6", "minipass-sized": "^1.0.3", "minizlib": "^2.1.2" }, "optionalDependencies": { "encoding": "^0.1.13" } }, "sha512-LT49Zi2/WMROHYoqGgdlQIZh8mLPZmOrN2NdJjMXxYe4nkN6FUyuPuOAOedNJDrx0IRGg9+4guZewtp8hE6TxA=="],
@@ -2954,6 +2932,8 @@
     "read-package-json/glob/minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
 
     "read-package-json/glob/path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
+
+    "rimraf/glob/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
 
     "rollup-plugin-api-extractor/@microsoft/api-extractor/@microsoft/api-extractor-model": ["@microsoft/api-extractor-model@7.32.2", "", { "dependencies": { "@microsoft/tsdoc": "~0.16.0", "@microsoft/tsdoc-config": "~0.18.0", "@rushstack/node-core-library": "5.19.1" } }, "sha512-Ussc25rAalc+4JJs9HNQE7TuO9y6jpYQX9nWD1DhqUzYPBr3Lr7O9intf+ZY8kD5HnIqeIRJX7ccCT0QyBy2Ww=="],
 
@@ -3023,8 +3003,6 @@
 
     "@manypkg/find-root/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
 
-    "@npmcli/move-file/rimraf/glob/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
-
     "@react-native/codegen/@babel/parser/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
 
     "@react-native/codegen/@babel/parser/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
@@ -3042,8 +3020,6 @@
     "cacache/glob/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
     "cacache/glob/path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
-
-    "chromium-edge-launcher/rimraf/glob/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
 
     "favicons/sharp/@img/sharp-wasm32/@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
 
@@ -3079,6 +3055,8 @@
 
     "read-package-json/glob/path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
+    "rimraf/glob/minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
+
     "rollup-plugin-api-extractor/@microsoft/api-extractor/@microsoft/tsdoc-config/ajv": ["ajv@8.12.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2", "uri-js": "^4.2.2" } }, "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA=="],
 
     "rollup-plugin-api-extractor/@microsoft/api-extractor/@rushstack/node-core-library/ajv": ["ajv@8.13.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2", "uri-js": "^4.4.1" } }, "sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA=="],
@@ -3105,13 +3083,9 @@
 
     "@manypkg/find-root/find-up/locate-path/p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
 
-    "@npmcli/move-file/rimraf/glob/minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
-
     "@react-native/dev-middleware/serve-static/send/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
     "cacache/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
-
-    "chromium-edge-launcher/rimraf/glob/minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
 
     "node-gyp/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
@@ -3123,13 +3097,11 @@
 
     "read-package-json/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
+    "rimraf/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
     "rollup-plugin-api-extractor/@microsoft/api-extractor/@rushstack/node-core-library/fs-extra/universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
 
     "test-exclude/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
-
-    "@npmcli/move-file/rimraf/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
-
-    "chromium-edge-launcher/rimraf/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "node-gyp/make-fetch-happen/cacache/glob/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 

--- a/packages/atlas/src/scanner/scanner.test.ts
+++ b/packages/atlas/src/scanner/scanner.test.ts
@@ -1,4 +1,10 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -170,5 +176,22 @@ describe('scanWorkspace', () => {
 
     const graph = scanWorkspace(baseConfig)
     expect(graph.nodes[0]?.private).toBe(true)
+  })
+
+  // Regression guard for the withFileTypes optimization: a package
+  // directory reached via a symlink must still be discovered. statSync
+  // follows symlinks; Dirent.isDirectory() does not — so the optimized
+  // listDirectories must special-case symlinked entries.
+  it('should discover a package dir reached via a symlink', () => {
+    const realDir = join(tmpDir, 'real-pkg')
+    mkdirSync(realDir, { recursive: true })
+    writeFileSync(
+      join(realDir, 'package.json'),
+      JSON.stringify({ name: '@scope/linked', version: '1.0.0' }),
+    )
+    symlinkSync(realDir, join(tmpDir, 'packages', 'linked'), 'dir')
+
+    const graph = scanWorkspace(baseConfig)
+    expect(graph.nodes.map((n) => n.name)).toContain('@scope/linked')
   })
 })

--- a/packages/atlas/src/scanner/scanner.ts
+++ b/packages/atlas/src/scanner/scanner.ts
@@ -47,15 +47,22 @@ const stripTrailingSlashes = (s: string): string => {
 
 const listDirectories = (base: string): string[] => {
   try {
-    return readdirSync(base)
-      .map((entry) => join(base, entry))
-      .filter((p) => {
+    const result: string[] = []
+    for (const entry of readdirSync(base, { withFileTypes: true })) {
+      const p = join(base, entry.name)
+      if (entry.isDirectory()) {
+        result.push(p)
+      } else if (entry.isSymbolicLink()) {
+        // Dirent.isDirectory() is false for symlinks; statSync follows
+        // the link. Monorepos symlink package dirs, so resolve those.
         try {
-          return statSync(p).isDirectory()
+          if (statSync(p).isDirectory()) result.push(p)
         } catch {
-          return false
+          // broken symlink — skip
         }
-      })
+      }
+    }
+    return result
   } catch {
     return []
   }

--- a/packages/rolldown/package.json
+++ b/packages/rolldown/package.json
@@ -43,7 +43,6 @@
   "dependencies": {
     "@vitus-labs/tools-core": "workspace:^",
     "chalk": "^5.6.2",
-    "rimraf": "^6.1.3",
     "rolldown": "^1.0.0-rc.17",
     "rolldown-plugin-dts": "^0.23.2",
     "rollup-plugin-filesize": "^10.0.0",

--- a/packages/rolldown/src/scripts/build.test.ts
+++ b/packages/rolldown/src/scripts/build.test.ts
@@ -27,6 +27,7 @@ vi.mock('node:fs', () => ({
   unlinkSync: vi.fn(),
   cpSync: vi.fn(),
   mkdirSync: vi.fn(),
+  rmSync: vi.fn(),
 }))
 
 vi.mock('../config/index.ts', () => ({
@@ -217,6 +218,48 @@ describe('build', () => {
     mockBuildAllDts.mockReturnValue([])
 
     await expect(runBuild()).rejects.toThrow('rolldown failed')
+  })
+
+  it('cleans up the isolated temp dir even when DTS post-processing throws', async () => {
+    vi.resetModules()
+    const { runBuild } = await import('./build.js')
+    const { rmSync } = await import('node:fs')
+    vi.clearAllMocks()
+
+    mockRolldown.mockResolvedValue({
+      write: mockBundleWrite,
+      close: mockBundleClose,
+    })
+    mockBundleWrite.mockResolvedValue(undefined)
+    mockBundleClose.mockResolvedValue(undefined)
+    mockRolldownConfig.mockImplementation((item: any) => ({
+      input: 'src',
+      output: {
+        dir: 'lib',
+        entryFileNames: 'index.js',
+        format: item.format,
+      },
+    }))
+    mockBuildAllDts.mockReturnValue([
+      {
+        file: './lib/index.d.ts',
+        input: 'src/index.ts',
+        output: { dir: 'lib', entryFileNames: 'index.d.ts', format: 'es' },
+      },
+    ])
+    // DTS bundle build succeeds, but reading the temp dir afterward throws —
+    // simulating any failure in the window after the temp dir is created.
+    mockReaddirSync.mockImplementation(() => {
+      throw new Error('readdir blew up mid-DTS')
+    })
+
+    await expect(runBuild()).rejects.toThrow('readdir blew up mid-DTS')
+
+    // The temp dir MUST still be removed despite the throw (finally cleanup).
+    expect(rmSync).toHaveBeenCalledWith(
+      expect.stringContaining('__dts_tmp_'),
+      expect.objectContaining({ recursive: true, force: true }),
+    )
   })
 
   it('should handle multiple builds in sequence', async () => {

--- a/packages/rolldown/src/scripts/build.ts
+++ b/packages/rolldown/src/scripts/build.ts
@@ -1,7 +1,13 @@
-import { cpSync, mkdirSync, readdirSync, renameSync, statSync } from 'node:fs'
+import {
+  cpSync,
+  mkdirSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  statSync,
+} from 'node:fs'
 import { join } from 'node:path'
 import chalk from 'chalk'
-import { rimraf } from 'rimraf'
 import { rolldown } from 'rolldown'
 import { CONFIG, PKG } from '../config/index.ts'
 import {
@@ -94,40 +100,46 @@ const buildDtsIsolated = async (
   const finalDir = output.dir as string
   const entryName = output.entryFileNames as string
   const tempDir = join(finalDir, `__dts_tmp_${entryName.replace(/\W/g, '_')}`)
-
-  // Build into isolated temp directory
-  const tempOutput = { ...output, dir: tempDir }
-  await build({ inputOptions: input, outputOptions: tempOutput })
-
-  // Find the largest .d.ts file — that's the real declarations
   const absTempDir = join(process.cwd(), tempDir)
-  const dtsFiles = readdirSync(absTempDir).filter((f) => f.endsWith('.d.ts'))
 
-  let bestFile = dtsFiles[0] || entryName
-  let bestSize = 0
-  for (const f of dtsFiles) {
-    const size = statSync(join(absTempDir, f)).size
-    if (size > bestSize) {
-      bestSize = size
-      bestFile = f
-    }
-  }
-
-  // Move the best file to the final location
-  const absFinalDir = join(process.cwd(), finalDir)
-  mkdirSync(absFinalDir, { recursive: true })
-  renameSync(join(absTempDir, bestFile), join(absFinalDir, entryName))
-
-  // Move sourcemap if it exists
-  const mapName = `${bestFile}.map`
   try {
-    renameSync(join(absTempDir, mapName), join(absFinalDir, `${entryName}.map`))
-  } catch {
-    // sourcemap may not exist
-  }
+    // Build into isolated temp directory
+    const tempOutput = { ...output, dir: tempDir }
+    await build({ inputOptions: input, outputOptions: tempOutput })
 
-  // Clean up temp directory
-  rimraf.sync(absTempDir)
+    // Find the largest .d.ts file — that's the real declarations
+    const dtsFiles = readdirSync(absTempDir).filter((f) => f.endsWith('.d.ts'))
+
+    let bestFile = dtsFiles[0] || entryName
+    let bestSize = 0
+    for (const f of dtsFiles) {
+      const size = statSync(join(absTempDir, f)).size
+      if (size > bestSize) {
+        bestSize = size
+        bestFile = f
+      }
+    }
+
+    // Move the best file to the final location
+    const absFinalDir = join(process.cwd(), finalDir)
+    mkdirSync(absFinalDir, { recursive: true })
+    renameSync(join(absTempDir, bestFile), join(absFinalDir, entryName))
+
+    // Move sourcemap if it exists
+    const mapName = `${bestFile}.map`
+    try {
+      renameSync(
+        join(absTempDir, mapName),
+        join(absFinalDir, `${entryName}.map`),
+      )
+    } catch {
+      // sourcemap may not exist
+    }
+  } finally {
+    // Always remove the temp dir — even if the build or a post-step
+    // throws — so a partial failure can't leak __dts_tmp_* into lib/.
+    rmSync(absTempDir, { recursive: true, force: true })
+  }
 }
 
 const generateDeclarations = async () => {
@@ -155,7 +167,10 @@ const runBuild = async () => {
   )
 
   log(`${dim('Cleaning')} ${CONFIG.outputDir}/`)
-  rimraf.sync(`${process.cwd()}/${CONFIG.outputDir}`)
+  rmSync(`${process.cwd()}/${CONFIG.outputDir}`, {
+    recursive: true,
+    force: true,
+  })
 
   log(
     `${dim('Building')} ${bold(String(allBuildsCount))} bundle${allBuildsCount > 1 ? 's' : ''}...\n`,

--- a/packages/rollup/package.json
+++ b/packages/rollup/package.json
@@ -47,7 +47,6 @@
     "chalk": "^5.6.2",
     "find-up": "^8.0.0",
     "lodash-es": "^4.18.1",
-    "rimraf": "^6.1.3",
     "rollup": "^4.60.2",
     "rollup-plugin-api-extractor": "^0.2.5",
     "rollup-plugin-filesize": "^10.0.0",

--- a/packages/rollup/src/scripts/build.test.ts
+++ b/packages/rollup/src/scripts/build.test.ts
@@ -13,7 +13,7 @@ const {
 }))
 
 vi.mock('rollup', () => ({ rollup: mockRollup }))
-vi.mock('rimraf', () => ({ rimraf: { sync: vi.fn() } }))
+vi.mock('node:fs', () => ({ rmSync: vi.fn() }))
 
 vi.mock('../config/index.ts', () => ({
   CONFIG: { outputDir: 'lib' },

--- a/packages/rollup/src/scripts/build.ts
+++ b/packages/rollup/src/scripts/build.ts
@@ -1,5 +1,5 @@
+import { rmSync } from 'node:fs'
 import chalk from 'chalk'
-import { rimraf } from 'rimraf'
 import { rollup } from 'rollup'
 import { CONFIG } from '../config/index.ts'
 import { createBuildPipeline, config as rollupConfig } from '../rollup/index.ts'
@@ -75,7 +75,10 @@ const runBuild = async () => {
     )}`,
   )
 
-  rimraf.sync(`${process.cwd()}/${CONFIG.outputDir}`)
+  rmSync(`${process.cwd()}/${CONFIG.outputDir}`, {
+    recursive: true,
+    force: true,
+  })
 
   log(
     `${chalk.bold.bgBlue.black('[2/4]')} ${chalk.blue('☑️  Old build removed')}`,


### PR DESCRIPTION
## Senior QA + Architecture audit

Swept the codebase for bottlenecks, memory leaks, and edge cases. Everything below is **proven, measured, and verified e2e**. Equally important — several reported concerns were **disproven** and deliberately left untouched.

## Investigated and disproven (no changes made)

| Reported concern | Verdict (traced in code) |
|---|---|
| `depth.ts` longest-path logic inverted | **False.** Traced A→B→C → depthMap A=2,B=1,C=0, critical path A→B→C. Correct. |
| `cycles.ts` self-loop corrupts reconstruction | **False.** `reconstructCycle`'s `while (curr && curr !== v)` guard yields `[a]` correctly. |
| `bundle-size.ts` naive `readdir`+`statSync` | **False.** Already uses `withFileTypes` + `MAX_DIR_DEPTH` guard; `statSync` only for file `.size` (unavoidable). |
| `bundle-size.ts` transitive double-count | **False.** Shared `visited` set is intentional dedup — correct for unique transitive byte size. |
| Memory leaks (timers/listeners/caches) | **None.** Watch CLI `SIGINT` closes the watcher; no unbounded module-level state anywhere. |

## Fixed (proven)

### 1. atlas scanner — N+1 `statSync` syscalls

`listDirectories` did `readdirSync` then `statSync` per entry. Now `readdirSync(base, { withFileTypes: true })`, falling back to `statSync` only for symlinks (which `Dirent.isDirectory()` can't resolve — monorepos symlink package dirs).

**Measured** (standalone script, 50 dirs + 5 symlinks + 10 files):
```
OLD statSync syscalls:  65
NEW statSync syscalls:  5  (only the symlinks)
Reduction:              65 -> 5  (92% fewer)
Same dirs discovered:   true
```
Complexity: O(entries) → O(symlinks). Regression test added asserting a symlinked package dir is still discovered.

### 2. rolldown `buildDtsIsolated` — temp-dir leak on error path

Cleanup ran only on the success path. A throw anywhere mid-DTS (build, `readdirSync`, `statSync`, `renameSync`) leaked `__dts_tmp_*` into `lib/` — which ships, since `files: ["lib"]`. Moved cleanup into `finally`.

**Proof test** asserts cleanup runs when post-processing throws. On the old code: `Number of calls: 0` (fails). After fix: passes. Full build leaves **zero** `__dts_tmp` dirs.

### 3. rolldown + rollup — drop the `rimraf` dependency

Both packages require Node ≥ 22, where built-in `fs.rmSync(p, { recursive: true, force: true })` is equivalent to `rimraf.sync`. Removed `rimraf` as a direct dependency from both — one fewer runtime dep + supply-chain surface, zero behavior change.

## e2e verification

- ✅ 565 tests pass (was 563 + 2 new proof tests)
- ✅ Leak proof test: red on old code → green after fix
- ✅ Symlink regression test: behavior identical (92% fewer syscalls)
- ✅ Typecheck + lint clean across all 10 packages
- ✅ All 10 packages build; zero leaked `__dts_tmp` dirs
- ✅ `rimraf` removed from both package.json + lockfile

## Versioning

`tools-atlas`, `tools-rolldown`, `tools-rollup`: **patch** — bug/perf fixes, no API change. Fixed group → all 12 land at next patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)