### PR TITLE
fix(rolldown): dedupe shared modules across multi-entry packages

### DIFF
--- a/.changeset/rolldown-multi-entry-dedup.md
+++ b/.changeset/rolldown-multi-entry-dedup.md
@@ -1,0 +1,20 @@
+---
+'@vitus-labs/tools-rolldown': minor
+---
+
+Fix correctness bug: multi-subpath packages now dedupe shared modules into a chunk instead of inlining a separate copy into every entry.
+
+**Before**: each sub-entry was a separate `rolldown()` invocation with a single input, so any module imported by 2+ entries was inlined into each entry's output. For pure-function code this was wasted bytes; for modules with module-level identity-bearing state (`createContext`, `Symbol.for`/`Symbol(...)` factories, singleton registries, etc.) it was a silent **correctness bug** — each inlined copy minted its own identity at module-eval time, and cross-entry lookups failed without warning. Surfaced in the field as silently-dropped SEO meta tags in `@pyreon/head`'s SSR path.
+
+**After**: variants are partitioned by `(format, env, platform)`. Groups of 2+ entries that all use chunkable formats (i.e. not UMD/IIFE) are emitted in a **single** rolldown invocation with `input` as an entry map and `chunkFileNames: '_chunks/[name]-[hash].js'`. Rolldown's native multi-entry mode then emits any module imported by ≥2 entries as one shared chunk; entries `import` from it. Singletons and UMD/IIFE keep the per-entry path unchanged.
+
+Verified on a minimal `@pyreon/head`-shaped reproduction (3 sub-entries sharing a `sentinel.ts` exporting `Symbol(...)` + `Map`):
+
+| | before | after |
+|---|---|---|
+| `Symbol("shared-sentinel")` occurrences across all `.js` outputs | 3 (one per entry) | **1** (in shared chunk) |
+| `SENTINEL` identity equal across all entries | **false** | **true** |
+| `idx.REGISTRY.size` after `use.writeFromUse(...)` | 0 (write lost) | **1** |
+| `peek.peekFromPeek()` after that write | `undefined` | `'hello from use'` |
+
+DTS generation is unchanged (still per-entry through `buildDtsIsolated`) — types carry no runtime identity, so per-entry is fine and keeps the DTS pipeline simple.

--- a/packages/rolldown/src/scripts/build.shared-chunks.integration.test.ts
+++ b/packages/rolldown/src/scripts/build.shared-chunks.integration.test.ts
@@ -1,0 +1,77 @@
+import { execFileSync } from 'node:child_process'
+import { existsSync, readdirSync, readFileSync, rmSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const FIXTURE = resolve(
+  __dirname,
+  '..',
+  '..',
+  'test-fixtures',
+  'multi-entry-sharing',
+)
+const BIN = resolve(__dirname, '..', 'bin', 'run-build.ts')
+const LIB = join(FIXTURE, 'lib')
+
+const cleanup = () => rmSync(LIB, { recursive: true, force: true })
+
+const countSubstring = (haystack: string, needle: string): number =>
+  haystack.split(needle).length - 1
+
+describe('rolldown multi-entry shared-chunk dedup', () => {
+  beforeAll(() => {
+    cleanup()
+    execFileSync('bun', ['run', BIN], { cwd: FIXTURE, stdio: 'pipe' })
+  }, 60_000)
+
+  afterAll(cleanup)
+
+  it('emits a shared chunk for the module imported by 2+ entries', () => {
+    expect(existsSync(join(LIB, '_chunks'))).toBe(true)
+    const chunks = readdirSync(join(LIB, '_chunks')).filter((f) =>
+      f.endsWith('.js'),
+    )
+    expect(chunks.length).toBeGreaterThanOrEqual(1)
+
+    // Sum every Symbol("shared-sentinel") literal across all .js outputs.
+    // Bug shape: 3 (inlined into each entry). Fix shape: 1 (in shared chunk).
+    const allJs = [
+      ...readdirSync(LIB)
+        .filter((f) => f.endsWith('.js'))
+        .map((f) => join(LIB, f)),
+      ...chunks.map((f) => join(LIB, '_chunks', f)),
+    ]
+    const total = allJs.reduce(
+      (n, f) =>
+        n +
+        countSubstring(readFileSync(f, 'utf8'), 'Symbol("shared-sentinel")'),
+      0,
+    )
+    expect(total).toBe(1)
+  })
+
+  it('preserves shared module identity across sub-entries (regression for @pyreon/head)', async () => {
+    const idx = await import(`${LIB}/index.js`)
+    const use = await import(`${LIB}/use.js`)
+    const peek = await import(`${LIB}/peek.js`)
+
+    // Identity: the Symbol exported from each entry must be the same value.
+    expect(idx.SENTINEL).toBe(use.sentinelFromUse())
+    expect(idx.SENTINEL).toBe(peek.sentinelFromPeek())
+    expect(use.sentinelFromUse()).toBe(peek.sentinelFromPeek())
+
+    // Cross-entry state: write via one entry, read via another. Was the
+    // failure mode that dropped @pyreon/head's SEO meta tags silently.
+    use.writeFromUse('hello from use')
+    expect(idx.REGISTRY.size).toBe(1)
+    expect(peek.peekFromPeek()).toBe('hello from use')
+  })
+
+  it('still emits one .js file per declared sub-entry', () => {
+    expect(existsSync(join(LIB, 'index.js'))).toBe(true)
+    expect(existsSync(join(LIB, 'use.js'))).toBe(true)
+    expect(existsSync(join(LIB, 'peek.js'))).toBe(true)
+  })
+})

--- a/packages/rolldown/src/scripts/build.ts
+++ b/packages/rolldown/src/scripts/build.ts
@@ -43,32 +43,130 @@ async function build({
   await bundle.close()
 }
 
-const createBuilds = async () => {
-  let p = Promise.resolve()
-
-  allBuilds.forEach((item: Record<string, any>) => {
-    const { output, ...input } = rolldownConfig(item)
-    const format = FORMAT_LABEL[output.format] || output.format
-    p = p.then(() => {
-      const start = performance.now()
-
-      return build({ inputOptions: input, outputOptions: output })
-        .then(() => {
-          const duration = Math.round(performance.now() - start)
-          log(
-            `  ${chalk.green('+')} ${bold(format)} ${dim('->')} ${dim(`${output.dir}/${output.entryFileNames}`)} ${dim(`(${duration}ms)`)}`,
-          )
-        })
-        .catch((e) => {
-          log(`\n${chalk.bold.red('Build failed')}`)
-          log(chalk.gray(`  Format: ${format}`))
-          log(chalk.gray(`  File:   ${output.dir}/${output.entryFileNames}`))
-          log(e)
-          throw e
-        })
-    })
+/**
+ * Longest common parent directory of a list of file paths.
+ * '/lib/index.js' + '/lib/component.js' -> '/lib'
+ * '/lib/index.js' + '/lib/sub/foo.js'   -> '/lib'
+ */
+const commonParent = (files: string[]): string => {
+  if (files.length === 0) return '.'
+  const split = files.map((f) => {
+    const i = f.lastIndexOf('/')
+    return i >= 0 ? f.substring(0, i).split('/') : ['.']
   })
+  const head = split[0] as string[]
+  let common: string[] = head
+  for (const s of split.slice(1)) {
+    const next: string[] = []
+    for (let i = 0; i < Math.min(common.length, s.length); i++) {
+      if (common[i] === s[i]) next.push(common[i] as string)
+      else break
+    }
+    common = next
+  }
+  return common.length === 0 ? '.' : common.join('/')
+}
 
+const stripJsExt = (s: string): string => s.replace(/\.(m?js|cjs)$/, '')
+
+/**
+ * Partition variants into groups eligible for multi-entry shared-chunk
+ * builds, and singletons that keep the per-entry path.
+ *
+ * Eligible: same (format, env, platform), explicit `input` set, and a
+ * format that supports code-splitting (i.e. not umd/iife — those are
+ * inherently standalone bundles).
+ */
+const partitionForSharedChunks = (variants: Record<string, any>[]) => {
+  const buckets = new Map<string, Record<string, any>[]>()
+  const singles: Record<string, any>[] = []
+  for (const v of variants) {
+    if (!v.input || ['umd', 'iife'].includes(v.format)) {
+      singles.push(v)
+      continue
+    }
+    const key = `${v.format}|${v.env}|${v.platform}`
+    const bucket = buckets.get(key) ?? []
+    bucket.push(v)
+    buckets.set(key, bucket)
+  }
+  const groups: Record<string, any>[][] = []
+  for (const bucket of buckets.values()) {
+    if (bucket.length <= 1) singles.push(...bucket)
+    else groups.push(bucket)
+  }
+  return { groups, singles }
+}
+
+/** Build one group of multi-entry variants as a single rolldown invocation. */
+const buildGroup = async (group: Record<string, any>[]) => {
+  // Use the first variant as the representative for format/env/platform —
+  // they're identical across the group by construction.
+  const head = group[0] as Record<string, any>
+  const dir = commonParent(group.map((v) => v.file as string))
+  // Entry name = file relative to common parent, with .js/.cjs/.mjs stripped.
+  // rolldown preserves '/' in input keys, so nested entries map cleanly to
+  // nested output paths via [name] in entryFileNames.
+  const inputMap: Record<string, string> = {}
+  for (const v of group) {
+    const rel = (v.file as string).startsWith(`${dir}/`)
+      ? (v.file as string).substring(dir.length + 1)
+      : (v.file as string)
+    inputMap[stripJsExt(rel)] = v.input as string
+  }
+
+  // Build via the per-variant config to inherit plugins/externals/etc.,
+  // then override input + output for the group.
+  const { output, ...inputOptions } = rolldownConfig(head)
+  inputOptions.input = inputMap
+  const outputOptions = {
+    ...output,
+    dir,
+    entryFileNames: '[name].js',
+    chunkFileNames: '_chunks/[name]-[hash].js',
+  }
+
+  const format = FORMAT_LABEL[head.format] || head.format
+  const start = performance.now()
+  try {
+    await build({ inputOptions, outputOptions })
+  } catch (e) {
+    log(`\n${chalk.bold.red('Build failed')}`)
+    log(chalk.gray(`  Format:  ${format}`))
+    log(chalk.gray(`  Entries: ${Object.keys(inputMap).join(', ')}`))
+    log(e)
+    throw e
+  }
+  const duration = Math.round(performance.now() - start)
+  log(
+    `  ${chalk.green('+')} ${bold(format)} ${dim('->')} ${dim(`${dir}/{${Object.keys(inputMap).join(',')}}.js`)} ${dim(`(${duration}ms, shared chunks)`)}`,
+  )
+}
+
+const buildSingle = async (item: Record<string, any>) => {
+  const { output, ...inputOptions } = rolldownConfig(item)
+  const format = FORMAT_LABEL[output.format] || output.format
+  const start = performance.now()
+  try {
+    await build({ inputOptions, outputOptions: output })
+  } catch (e) {
+    log(`\n${chalk.bold.red('Build failed')}`)
+    log(chalk.gray(`  Format: ${format}`))
+    log(chalk.gray(`  File:   ${output.dir}/${output.entryFileNames}`))
+    log(e)
+    throw e
+  }
+  const duration = Math.round(performance.now() - start)
+  log(
+    `  ${chalk.green('+')} ${bold(format)} ${dim('->')} ${dim(`${output.dir}/${output.entryFileNames}`)} ${dim(`(${duration}ms)`)}`,
+  )
+}
+
+const createBuilds = async () => {
+  const { groups, singles } = partitionForSharedChunks(allBuilds)
+  let p = Promise.resolve()
+  for (const item of singles) p = p.then(() => buildSingle(item))
+  for (const group of groups) p = p.then(() => buildGroup(group))
   return p
 }
 

--- a/packages/rolldown/test-fixtures/multi-entry-sharing/package.json
+++ b/packages/rolldown/test-fixtures/multi-entry-sharing/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "multi-entry-sharing-fixture",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".":      { "types": "./lib/types/index.d.ts", "import": "./lib/index.js" },
+    "./use":  { "types": "./lib/types/use.d.ts",   "import": "./lib/use.js" },
+    "./peek": { "types": "./lib/types/peek.d.ts",  "import": "./lib/peek.js" }
+  }
+}

--- a/packages/rolldown/test-fixtures/multi-entry-sharing/src/index.ts
+++ b/packages/rolldown/test-fixtures/multi-entry-sharing/src/index.ts
@@ -1,0 +1,1 @@
+export { REGISTRY, SENTINEL } from './sentinel.ts'

--- a/packages/rolldown/test-fixtures/multi-entry-sharing/src/peek.ts
+++ b/packages/rolldown/test-fixtures/multi-entry-sharing/src/peek.ts
@@ -1,0 +1,3 @@
+import { REGISTRY, SENTINEL } from './sentinel.ts'
+export const peekFromPeek = () => REGISTRY.get('k')
+export const sentinelFromPeek = () => SENTINEL

--- a/packages/rolldown/test-fixtures/multi-entry-sharing/src/sentinel.ts
+++ b/packages/rolldown/test-fixtures/multi-entry-sharing/src/sentinel.ts
@@ -1,0 +1,3 @@
+// Identity-bearing module-level state — the @pyreon/head createContext shape.
+export const SENTINEL = Symbol('shared-sentinel')
+export const REGISTRY = new Map<string, unknown>()

--- a/packages/rolldown/test-fixtures/multi-entry-sharing/src/use.ts
+++ b/packages/rolldown/test-fixtures/multi-entry-sharing/src/use.ts
@@ -1,0 +1,3 @@
+import { REGISTRY, SENTINEL } from './sentinel.ts'
+export const writeFromUse = (value: unknown) => REGISTRY.set('k', value)
+export const sentinelFromUse = () => SENTINEL

--- a/packages/rolldown/test-fixtures/multi-entry-sharing/tsconfig.json
+++ b/packages/rolldown/test-fixtures/multi-entry-sharing/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2024",
+    "module": "Preserve",
+    "moduleResolution": "Bundler",
+    "verbatimModuleSyntax": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "declaration": true,
+    "noEmit": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary

Fix a silent correctness bug in multi-subpath packages built with \`@vitus-labs/tools-rolldown\`. Shared modules were inlined into every entry, so identity-bearing module-level state (\`createContext\`, \`Symbol(...)\` factories, singleton registries) minted distinct identities per entry — cross-entry lookups silently failed. Surfaced in the field as silently-dropped SEO meta tags in \`@pyreon/head\`'s SSR path.

## Root cause

\`createBuildPipeline\` produced one variant per sub-entry; \`build.ts\` called \`rolldown()\` once per variant with a single \`input\`. Rolldown can't emit a shared chunk from a single entry, so any module imported by 2+ entries was inlined into each.

## Fix

Partition variants by \`(format, env, platform)\`. Groups of ≥2 chunkable entries (i.e. not UMD/IIFE) → **one** \`rolldown()\` invocation with \`input\` as an entry map and \`chunkFileNames: '_chunks/[name]-[hash].js'\`. Native rolldown shared-chunk dedup does the rest. Singletons and UMD/IIFE keep the per-entry path. DTS still per-entry (types carry no runtime identity).

## Evidence (minimal \`@pyreon/head\`-shaped reproduction)

3 sub-entries (\`index\`, \`use\`, \`peek\`) sharing \`sentinel.ts\` that exports \`Symbol('shared-sentinel')\` + a \`Map\`:

| | before | after |
|---|---|---|
| \`Symbol(\"shared-sentinel\")\` literals across all \`.js\` outputs | 3 | **1** (in shared chunk) |
| \`SENTINEL\` \`===\` across entries | false | **true** |
| \`idx.REGISTRY.size\` after \`use.writeFromUse(...)\` | 0 (write lost) | **1** |
| \`peek.peekFromPeek()\` after that write | \`undefined\` | \`'hello from use'\` |

Built into the test suite as \`build.shared-chunks.integration.test.ts\` over a permanent fixture at \`test-fixtures/multi-entry-sharing/\`. The test would have FAILED on every \`tools-rolldown\` release before this PR.

## e2e verification

- ✅ **568 tests pass** (was 565 + 3 new shared-chunk regression tests)
- ✅ Existing DTS pipeline integration test still passes (per-entry DTS unchanged)
- ✅ Existing single-entry build behavior unchanged (singleton path preserved)
- ✅ typecheck + lint clean across all 10 packages
- ✅ All 10 monorepo packages build (own packages are mostly single-entry; verified the partition correctly falls back to per-entry for them)
- ✅ Zero leaked \`__dts_tmp\` dirs

## Edge cases handled

- **Single-entry packages**: partition demotes 1-element groups back to singletons → identical behavior to before
- **UMD/IIFE**: kept on the singleton path (standalone bundles can't share chunks)
- **Variants without explicit \`input\`** (legacy \`main\`/\`module\` fields): kept on the singleton path
- **Nested output paths** (e.g. \`./lib/sub/foo.js\`): common-parent computation preserves the relative entry name, so rolldown's \`[name]\` substitution writes to the correct nested path

## Versioning

\`@vitus-labs/tools-rolldown\`: **minor** — fixes a correctness bug + introduces a new \`_chunks/\` directory in multi-entry package outputs (additive, no consumer code change needed). Fixed group → all 12 packages land at next minor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)