### PR TITLE
feat(rolldown): expose sourcemap as a configurable option

### DIFF
--- a/.changeset/rolldown-configurable-sourcemap.md
+++ b/.changeset/rolldown-configurable-sourcemap.md
@@ -1,0 +1,27 @@
+---
+'@vitus-labs/tools-rolldown': minor
+---
+
+Expose `sourcemap` as a configurable option, mirroring rolldown's native `output.sourcemap` API. Previously hardcoded to `true`.
+
+```js
+// vl-tools.config.mjs
+export default {
+  build: {
+    sourcemap: 'hidden', // boolean | 'inline' | 'hidden', default: true
+  },
+}
+```
+
+Semantics (verified end-to-end against on-disk artifacts):
+
+| value | `.js.map` file | `sourceMappingURL` comment | inline data URL |
+|---|---|---|---|
+| `true` (default) | yes | yes | no |
+| `'hidden'` | yes | **no** | no |
+| `'inline'` | no | yes | yes (base64 embedded) |
+| `false` | no | no | no |
+
+Motivating use case: closed-source consumers who want maps for error-reporting services (Sentry, Datadog) without shipping the `sourceMappingURL` comment that leaks source in the deployed bundle — `'hidden'` is the answer.
+
+Default is `true` — existing builds are bit-for-bit unchanged.

--- a/packages/rolldown/src/config/baseConfig.test.ts
+++ b/packages/rolldown/src/config/baseConfig.test.ts
@@ -12,6 +12,10 @@ describe('baseConfig', () => {
     expect(baseConfig.typescript).toBe(true)
   })
 
+  it('should default sourcemap to true (backward-compatible)', () => {
+    expect(baseConfig.sourcemap).toBe(true)
+  })
+
   it('should include all expected file extensions', () => {
     const expectedExtensions = [
       '.json',

--- a/packages/rolldown/src/config/baseConfig.ts
+++ b/packages/rolldown/src/config/baseConfig.ts
@@ -11,6 +11,13 @@ export default {
     outputDir: 'analysis',
   },
   filesize: true,
+  // JS-bundle sourcemap. Mirrors rolldown's native output.sourcemap:
+  //   true     — separate .js.map file + sourceMappingURL comment (default)
+  //   'hidden' — separate .js.map file, NO comment (debugging without leak)
+  //   'inline' — base64 map embedded in the .js file
+  //   false    — no map emitted
+  // DTS output does not include sourcemaps (declarations don't need them).
+  sourcemap: true as boolean | 'inline' | 'hidden',
   extensions: ['.json', '.js', '.jsx', '.ts', '.tsx', '.es6', '.es', '.mjs'],
   include: ['src'],
   external: ['react/jsx-runtime'],

--- a/packages/rolldown/src/rolldown/config.test.ts
+++ b/packages/rolldown/src/rolldown/config.test.ts
@@ -36,6 +36,7 @@ const { mockConfig, mockPKG } = vi.hoisted(() => ({
     replaceGlobals: true,
     visualise: { template: 'network', gzipSize: true, outputDir: 'analysis' },
     filesize: true,
+    sourcemap: true,
     external: ['react/jsx-runtime'],
     globals: { react: 'React' },
   } as Record<string, any>,
@@ -296,6 +297,34 @@ describe('rolldownConfig', () => {
 
     expect(config.output.dir).toBe('.')
     expect(config.output.entryFileNames).toBe('bundle.js')
+  })
+
+  describe('sourcemap is configurable (mirrors rolldown native API)', () => {
+    const buildWith = (sourcemap: unknown) => {
+      mockConfig.sourcemap = sourcemap
+      return rolldownConfig({
+        file: 'lib/index.js',
+        format: 'es',
+        env: 'development',
+        platform: 'universal',
+      })
+    }
+
+    it('threads true (default) into output', () => {
+      expect(buildWith(true).output.sourcemap).toBe(true)
+    })
+
+    it('threads false (no map emitted)', () => {
+      expect(buildWith(false).output.sourcemap).toBe(false)
+    })
+
+    it("threads 'hidden' (map file without sourceMappingURL comment)", () => {
+      expect(buildWith('hidden').output.sourcemap).toBe('hidden')
+    })
+
+    it("threads 'inline' (map embedded in bundle)", () => {
+      expect(buildWith('inline').output.sourcemap).toBe('inline')
+    })
   })
 })
 

--- a/packages/rolldown/src/rolldown/config.ts
+++ b/packages/rolldown/src/rolldown/config.ts
@@ -114,7 +114,7 @@ const rolldownConfig = ({
       entryFileNames: entryFileName,
       format,
       globals: swapGlobals(CONFIG.globals),
-      sourcemap: true,
+      sourcemap: CONFIG.sourcemap,
       sourcemapIgnoreList: (relativeSourcePath: string) =>
         relativeSourcePath.includes('node_modules'),
       exports: ['cjs', 'umd', 'iife'].includes(format)


### PR DESCRIPTION
## Summary

Expose \`sourcemap\` as a configurable option on \`@vitus-labs/tools-rolldown\`, mirroring rolldown's native \`output.sourcemap\` API. Previously hardcoded to \`true\`.

\`\`\`js
// vl-tools.config.mjs
export default {
  build: {
    sourcemap: 'hidden', // boolean | 'inline' | 'hidden', default: true
  },
}
\`\`\`

## Motivation

Hit in the field — closed-source consumers need maps shipped to error-reporting services (Sentry, Datadog) but **not** a \`sourceMappingURL\` comment in the deployed bundle that leaks source. \`'hidden'\` is the canonical answer: separate \`.map\` file, no comment.

## Semantics (verified on disk, not just in types)

| \`sourcemap\` | \`.js.map\` file | \`sourceMappingURL\` comment | inline data URL |
|---|---|---|---|
| \`true\` (default) | yes | yes | no |
| \`'hidden'\` | yes | **no** | no |
| \`'inline'\` | no | yes | yes (base64 embedded) |
| \`false\` | no | no | no |

Every row above was verified by building a real fixture with each value and inspecting the resulting \`lib/\` artifacts — not just asserting types flow through config. The matrix matched row-for-row.

## Tests

- baseConfig default assertion (`sourcemap === true` for backward compat)
- 4 new config-flow tests, one per value, asserting `CONFIG.sourcemap` → `output.sourcemap`
- All 573 tests pass (was 568 + 5 new), typecheck + lint clean across all 10 packages, all 10 packages build

## Compatibility

Default is \`true\` — **existing builds are bit-for-bit unchanged**. Purely additive surface.

## Versioning

\`@vitus-labs/tools-rolldown\`: **minor** — new config option. Fixed group → all 12 packages land at next minor.

## Docs

[vitus-labs/docs](https://github.com/vitus-labs/docs) updated with config-reference line and a dedicated \`## Sourcemaps\` section explaining the 4 values + the canonical \`'hidden'\` use case (committed separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)