### PR TITLE
fix(rolldown): default-externalize node:* builtins

### DIFF
--- a/.changeset/external-node-builtins.md
+++ b/.changeset/external-node-builtins.md
@@ -1,0 +1,13 @@
+---
+'@vitus-labs/tools-rolldown': patch
+---
+
+Default-externalize Node builtins (`node:*` imports) in the base config.
+
+Without this, every package that imports `node:fs`, `node:path`, etc. — which is most of them — triggers an `[UNRESOLVED_IMPORT] Could not resolve 'node:fs'` warning on every build. Rolldown is treating them as external implicitly anyway (so output is correct), but the warnings are noise and obscure real unresolved imports.
+
+Single-line change in `packages/rolldown/src/config/baseConfig.ts` — adds `/^node:/` (a RegExp) to the default `external` list. `expandExternal` in `@vitus-labs/tools-core` passes RegExps through unchanged (proven shape; PR #112), so this composes with the per-package string list with no per-package changes needed.
+
+Verified on this monorepo's own packages (atlas, mcp, favicon, rolldown, rollup all import `node:*`): **0 `UNRESOLVED_IMPORT` warnings during build**, builds produce identical output (the imports were already being externalized — only the warning is silenced).
+
+**Side note on the related `SOURCEMAP_BROKEN` fix that was proposed:** verified — it doesn't reproduce in our current code. The warning fires only when DTS sourcemap is enabled (`output.sourcemap: true`), and our DTS config hardcodes `sourcemap: false`. Adding an `onwarn` handler would be a defensive no-op. Skipped for now; can revisit if DTS sourcemap ever becomes configurable.

--- a/packages/rolldown/src/config/baseConfig.ts
+++ b/packages/rolldown/src/config/baseConfig.ts
@@ -20,7 +20,11 @@ export default {
   sourcemap: true as boolean | 'inline' | 'hidden',
   extensions: ['.json', '.js', '.jsx', '.ts', '.tsx', '.es6', '.es', '.mjs'],
   include: ['src'],
-  external: ['react/jsx-runtime'],
+  // node:* builtins are external by default — emits an UNRESOLVED_IMPORT
+  // warning on every package that imports `node:fs`, `node:path`, etc.
+  // without this. expandExternal in tools-core passes RegExp through
+  // unchanged, so this composes with the per-package string list.
+  external: ['react/jsx-runtime', /^node:/] as (string | RegExp)[],
   exclude: [
     'lib',
     'node_modules/**',


### PR DESCRIPTION
## Summary

Two-line fix that silences the \`[UNRESOLVED_IMPORT] Could not resolve 'node:fs'\` warning that fires on every package using \`node:*\` builtins — which is most of them.

### What

Adds \`/^node:/\` (a RegExp) to the default \`external\` list in \`packages/rolldown/src/config/baseConfig.ts\`. \`expandExternal\` in \`@vitus-labs/tools-core\` already passes RegExps through unchanged (PR #112), so this composes cleanly with the per-package string list — no per-package config changes needed.

### Why

Rolldown was already externalizing \`node:*\` implicitly (output was correct), but the per-import warning is noise and obscures real unresolved-import problems.

## Verified

| Probe | Before | After |
|---|---|---|
| Fixture with \`import 'node:fs'\` + \`import 'node:path'\` | 2× \`UNRESOLVED_IMPORT\` warnings | 0 |
| Full \`bun run pkgs:build\` (this monorepo, ~10 packages) | many warnings (atlas/mcp/favicon/rolldown/rollup all import \`node:*\`) | **0** |
| Built lib content | \`import { readFileSync } from "node:fs"\` (externalized) | identical |
| 579 tests | pass | pass |
| typecheck + build (10/10) | pass | pass |

## Related: SOURCEMAP_BROKEN

Also asked to add \`onwarn\` to silence \`SOURCEMAP_BROKEN\` from \`rolldown-plugin-dts:fake-js\`. Investigated and **not shipping** — verified the warning only fires when DTS sourcemap is enabled (\`output.sourcemap: true\`), and our DTS config hardcodes \`sourcemap: false\`. The proposed handler would be a defensive no-op against a warning that doesn't currently fire. If DTS sourcemap ever becomes configurable, we can add it then.

## Versioning

\`@vitus-labs/tools-rolldown\`: **patch** — silences a warning; built output unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)