### PR TITLE
fix(rolldown): dedup entry stems in grouped DTS (2.6.1 ENOENT regression)

### DIFF
--- a/.changeset/fix-rolldown-dts-duplicate-stem.md
+++ b/.changeset/fix-rolldown-dts-duplicate-stem.md
@@ -1,0 +1,21 @@
+---
+'@vitus-labs/tools-rolldown': patch
+---
+
+Fix `ENOENT` crash in grouped DTS for packages with two subpath exports pointing at the same `types` path (e.g. `./jsx-runtime` and `./jsx-dev-runtime` sharing one implementation — common in JSX runtime compat layers).
+
+**The bug.** `buildDtsGrouped` dedup'd the rolldown `input` map by stem but pushed the same stem twice into `entryStems`. `promoteEntries` iterated `entryStems`, calling `pickRealDtsFor(stem, tempFiles, …)` against a snapshot of `tempFiles` it never refreshes. Iteration 1 renamed `<stem>2.d.ts` out of the temp dir; iteration 2's `pickRealDtsFor` still saw it in the stale snapshot and `statSync`'d → `ENOENT`. Build crashed; consumers like `@pyreon/preact-compat` (5 compat packages) could not build.
+
+**Fix (root cause).** `entryStems` now dedups the same way `inputMap` does — `if (!entryStems.includes(stem)) entryStems.push(stem)`.
+
+**Fix (belt-and-suspenders).** `pickRealDtsFor` now skips files that no longer exist via `existsSync` before `statSync`. Defends against any future overlap in candidate sets even with the stem-dedup in place.
+
+**Regression-lock.** New `build.dup-stem.integration.test.ts` + permanent fixture `test-fixtures/dup-stem/` that mirrors the @pyreon/preact-compat shape (two subpaths → same types path). **Proven**: temporarily removing the dedup fails the test with the exact ENOENT shape; removing only the `existsSync` guard keeps the test green (dedup alone is sufficient — guard is genuine defense in depth).
+
+Test asserts:
+- Build completes (no ENOENT)
+- Exactly one `.d.ts` at the dup stem, no leftover `<stem>N.d.ts` artifacts
+- File contains real declarations (not the plugin's `export { }` stub)
+- Strict `tsc --skipLibCheck=false` typecheck passes against the produced lib
+
+Why 2.6.1 tests missed it: existing DTS integration fixtures don't have two subpaths pointing at the same `types` path. The dup-stem fixture covers that shape explicitly.

--- a/packages/rolldown/src/scripts/build.dup-stem.integration.test.ts
+++ b/packages/rolldown/src/scripts/build.dup-stem.integration.test.ts
@@ -1,0 +1,89 @@
+import { execFileSync } from 'node:child_process'
+import { existsSync, readdirSync, readFileSync, rmSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+/**
+ * Regression for the 2.6.1 ENOENT crash on duplicate entry stems.
+ *
+ * Shape: two subpath exports map to the same `types` path — common when
+ * two runtimes share one implementation (e.g. JSX runtime + dev-runtime,
+ * or any compat-layer pattern). The fixture mirrors @pyreon/preact-compat:
+ *
+ *   "./jsx-runtime":     { types: "./lib/types/jsx-runtime.d.ts", ... }
+ *   "./jsx-dev-runtime": { types: "./lib/types/jsx-runtime.d.ts", ... }
+ *
+ * Both DTS configs land in the same grouped bucket with the same
+ * `output.entryFileNames` -> stem `jsx-runtime` appears twice in
+ * `entryStems`. Pre-fix, promoteEntries iterated the dup stem twice;
+ * iteration 1 renamed `jsx-runtime2.d.ts` out of the temp dir, iteration 2
+ * `statSync`ed it (via a stale `readdirSync` snapshot) → ENOENT.
+ */
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const FIXTURE = resolve(__dirname, '..', '..', 'test-fixtures', 'dup-stem')
+const BIN = resolve(__dirname, '..', 'bin', 'run-build.ts')
+const LIB = join(FIXTURE, 'lib')
+
+const cleanup = () => rmSync(LIB, { recursive: true, force: true })
+
+describe('rolldown DTS: duplicate entry stems (two subpaths → one types path)', () => {
+  beforeAll(() => {
+    cleanup()
+    execFileSync('bun', ['run', BIN], { cwd: FIXTURE, stdio: 'pipe' })
+  }, 60_000)
+
+  afterAll(cleanup)
+
+  it('completes the build without ENOENT on the dup stem', () => {
+    // beforeAll would have thrown if the build failed.
+    expect(existsSync(join(LIB, 'types'))).toBe(true)
+  })
+
+  it('produces exactly one .d.ts at the dup stem (the second subpath shares it)', () => {
+    const types = readdirSync(join(LIB, 'types')).filter((f) =>
+      f.endsWith('.d.ts'),
+    )
+    expect(types).toContain('jsx-runtime.d.ts')
+    // No leftover stubs / numbered artifacts from the plugin.
+    expect(types).not.toContain('jsx-runtime2.d.ts')
+    expect(types).not.toContain('jsx-runtime3.d.ts')
+  })
+
+  it('jsx-runtime.d.ts has real declarations (not the empty stub)', () => {
+    const content = readFileSync(
+      join(LIB, 'types', 'jsx-runtime.d.ts'),
+      'utf-8',
+    )
+    expect(content).toMatch(/jsx|Fragment/)
+    // The plugin's stub is literally `export { };` — fail if we shipped that.
+    expect(content.trim()).not.toBe('export { };')
+  })
+
+  it('produced .d.ts files typecheck strictly (skipLibCheck: false)', () => {
+    const probeDir = join(LIB, '__typecheck_probe')
+    rmSync(probeDir, { recursive: true, force: true })
+    const fs = require('node:fs') as typeof import('node:fs')
+    fs.mkdirSync(probeDir, { recursive: true })
+    fs.writeFileSync(
+      join(probeDir, 'tsconfig.json'),
+      JSON.stringify({
+        compilerOptions: {
+          target: 'ES2024',
+          module: 'Preserve',
+          moduleResolution: 'Bundler',
+          strict: true,
+          noEmit: true,
+          skipLibCheck: false,
+        },
+        include: ['../types/*.d.ts'],
+      }),
+    )
+    expect(() =>
+      execFileSync('bunx', ['tsc', '-p', join(probeDir, 'tsconfig.json')], {
+        stdio: 'pipe',
+      }),
+    ).not.toThrow()
+    rmSync(probeDir, { recursive: true, force: true })
+  }, 30_000)
+})

--- a/packages/rolldown/src/scripts/build.ts
+++ b/packages/rolldown/src/scripts/build.ts
@@ -288,7 +288,13 @@ const pickRealDtsFor = (
   let bestSize = -1
   for (const f of tempFiles) {
     if (!re.test(f)) continue
-    const size = statSync(join(absTempDir, f)).size
+    // `tempFiles` is a snapshot from `readdirSync`. A prior promoteEntries
+    // iteration may have moved this file out of `absTempDir`. Skip silently
+    // instead of throwing ENOENT — defends against any future overlap in
+    // candidate sets even with the stem-dedup in place.
+    const p = join(absTempDir, f)
+    if (!existsSync(p)) continue
+    const size = statSync(p).size
     if (size > bestSize) {
       bestSize = size
       best = f
@@ -378,10 +384,16 @@ const buildDtsGrouped = async (
 
   const inputMap: Record<string, string> = {}
   const entryStems: string[] = []
+  // Dedup: two subpath exports can share the same `types` path (e.g.
+  // `./jsx-runtime` and `./jsx-dev-runtime` both pointing at
+  // `./lib/types/jsx-runtime.d.ts`). `inputMap` already dedups by stem;
+  // entryStems must do the same — otherwise promoteEntries iterates
+  // the same stem twice and the second iteration's pickRealDtsFor
+  // statSync's a file the first iteration already renamed away (ENOENT).
   for (const g of group) {
     const stem = (g.output.entryFileNames as string).replace(/\.d\.ts$/, '')
     inputMap[stem] = g.input as string
-    entryStems.push(stem)
+    if (!entryStems.includes(stem)) entryStems.push(stem)
   }
 
   try {
@@ -441,7 +453,9 @@ const generateDeclarations = async () => {
     const tscStart = performance.now()
     await buildDtsGrouped(group)
     const tscDuration = Math.round(performance.now() - tscStart)
-    const names = group.map((g) => g.output.entryFileNames as string).join(', ')
+    const names = [
+      ...new Set(group.map((g) => g.output.entryFileNames as string)),
+    ].join(', ')
     log(
       `  ${chalk.green('+')} ${bold('DTS')} ${dim('->')} ${dim(
         `${group[0]?.output.dir}/{${names}}`,

--- a/packages/rolldown/test-fixtures/dup-stem/package.json
+++ b/packages/rolldown/test-fixtures/dup-stem/package.json
@@ -1,0 +1,6 @@
+{ "name":"dup-stem-fixture","version":"0.0.0","private":true,"type":"module",
+  "exports": {
+    ".":                 { "types":"./lib/types/index.d.ts",       "import":"./lib/index.js" },
+    "./jsx-runtime":     { "types":"./lib/types/jsx-runtime.d.ts", "import":"./lib/jsx-runtime.js" },
+    "./jsx-dev-runtime": { "types":"./lib/types/jsx-runtime.d.ts", "import":"./lib/jsx-runtime.js" }
+  } }

--- a/packages/rolldown/test-fixtures/dup-stem/src/index.ts
+++ b/packages/rolldown/test-fixtures/dup-stem/src/index.ts
@@ -1,0 +1,2 @@
+export { jsx } from './jsx-runtime.ts'
+export const FRAMEWORK = 'preact'

--- a/packages/rolldown/test-fixtures/dup-stem/src/jsx-dev-runtime.ts
+++ b/packages/rolldown/test-fixtures/dup-stem/src/jsx-dev-runtime.ts
@@ -1,0 +1,1 @@
+export * from './jsx-runtime.ts'

--- a/packages/rolldown/test-fixtures/dup-stem/src/jsx-runtime.ts
+++ b/packages/rolldown/test-fixtures/dup-stem/src/jsx-runtime.ts
@@ -1,0 +1,2 @@
+export const jsx = (tag: string) => ({ tag })
+export const Fragment = Symbol('Fragment')

--- a/packages/rolldown/test-fixtures/dup-stem/tsconfig.json
+++ b/packages/rolldown/test-fixtures/dup-stem/tsconfig.json
@@ -1,0 +1,1 @@
+{ "compilerOptions": { "target":"ES2024","module":"Preserve","moduleResolution":"Bundler","verbatimModuleSyntax":true,"esModuleInterop":true,"skipLibCheck":true,"strict":true,"declaration":true,"noEmit":true }, "include":["src"] }


### PR DESCRIPTION
## The bug (build-breaking regression in 2.6.1)

Two subpath exports can share the same \`types\` path — common for JSX runtime + dev-runtime / compat layers:

\`\`\`json
"./jsx-runtime":     { "types": "./lib/types/jsx-runtime.d.ts", ... },
"./jsx-dev-runtime": { "types": "./lib/types/jsx-runtime.d.ts", ... }
\`\`\`

\`buildDtsGrouped\` dedup'd the rolldown \`input\` map by stem but pushed the same stem twice into \`entryStems\`. \`promoteEntries\` iterated \`entryStems\` against a snapshot of \`tempFiles\` it never refreshes:

- **Iteration 1** (`jsx-runtime`): picks \`jsx-runtime2.d.ts\` (largest), renames it away.
- **Iteration 2** (`jsx-runtime` again): \`pickRealDtsFor\` still sees \`jsx-runtime2.d.ts\` in the stale snapshot, calls \`statSync\` → **ENOENT**. Build crashes.

Affected 5 compat packages in \`@pyreon\` (react/preact/vue/solid/svelte).

## The fix

**Root cause** — dedup \`entryStems\` push:

\`\`\`diff
-entryStems.push(stem)
+if (!entryStems.includes(stem)) entryStems.push(stem)
\`\`\`

**Belt-and-suspenders** — \`pickRealDtsFor\` skips files that no longer exist:

\`\`\`diff
 if (!re.test(f)) continue
+const p = join(absTempDir, f)
+if (!existsSync(p)) continue
-const size = statSync(join(absTempDir, f)).size
+const size = statSync(p).size
\`\`\`

## Regression lock (proven)

New permanent fixture \`test-fixtures/dup-stem/\` mirroring \`@pyreon/preact-compat\` shape + \`build.dup-stem.integration.test.ts\`. The test:
- builds the fixture (must complete without ENOENT)
- asserts exactly one \`.d.ts\` at the dup stem, no leftover \`<stem>N.d.ts\` artifacts
- asserts content is real declarations (not the plugin's \`export { }\` stub)
- strict \`tsc --skipLibCheck=false\` typecheck against the produced lib

**Proven by reverting each fix:**

| Reverted | Test result |
|---|---|
| Both fixes in place | ✅ 4/4 pass |
| Only \`entryStems\` dedup removed | ❌ ENOENT fail (caught) |
| Only \`existsSync\` guard removed | ✅ 4/4 pass (dedup alone is sufficient) |

So dedup is the actual fix; the existsSync guard is genuine defense in depth.

## Why 2.6.1 missed it

Existing DTS integration fixtures had multiple subpaths but each with its own \`types\` path. The new \`dup-stem\` fixture covers the "two subpaths → one types path" shape explicitly going forward.

## e2e

- ✅ **585 tests pass** (+4 new for the dup-stem case)
- ✅ Lint + typecheck clean across all 10 packages
- ✅ All 10 packages build
- ✅ Compiled-bin test from 2.6.1 still green (node + bun runtimes)
- ✅ Zero leaked \`__dts_tmp*\` dirs

## Versioning

\`@vitus-labs/tools-rolldown\`: **patch** → 2.6.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)